### PR TITLE
refactor: move --app flag to persistent flag on entity command

### DIFF
--- a/cmd/entity.go
+++ b/cmd/entity.go
@@ -1,7 +1,7 @@
 /**
  * [INPUT]: 依赖 github.com/spf13/cobra
  * [OUTPUT]: 对外提供 newEntityCmd 函数
- * [POS]: cmd 模块的 entity 命令组，挂载 create / list 子命令
+ * [POS]: cmd 模块的 entity 命令组，挂载 create / delete / list 子命令，--app 参数为子命令继承
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -10,10 +10,22 @@ package cmd
 import "github.com/spf13/cobra"
 
 func newEntityCmd() *cobra.Command {
+	var app string
+
 	cmd := &cobra.Command{
 		Use:   "entity",
 		Short: "Manage entities",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if app == "" {
+				return cmd.Usage()
+			}
+			return nil
+		},
 	}
+
+	cmd.PersistentFlags().StringVar(&app, "app", "", "app name (required)")
+	cmd.MarkPersistentFlagRequired("app")
+
 	cmd.AddCommand(newEntityCreateCmd())
 	cmd.AddCommand(newEntityDeleteCmd())
 	cmd.AddCommand(newEntityListCmd())

--- a/cmd/entity_create.go
+++ b/cmd/entity_create.go
@@ -21,7 +21,6 @@ import (
 func newEntityCreateCmd() *cobra.Command {
 	var profile string
 	var server string
-	var app string
 	var fieldsFile string
 
 	cmd := &cobra.Command{
@@ -30,15 +29,14 @@ func newEntityCreateCmd() *cobra.Command {
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, _ := cmd.Parent().Flags().GetString("app")
 			return runEntityCreate(args[0], app, fieldsFile, profile, server)
 		},
 	}
 
-	cmd.Flags().StringVar(&app, "app", "", "app name to create entity in (required)")
 	cmd.Flags().StringVar(&fieldsFile, "fields", "", "path to JSON file containing fields array")
 	cmd.Flags().StringVar(&profile, "profile", "default", "credentials profile to use")
 	cmd.Flags().StringVar(&server, "server", defaultMetaServer, "Meta Server base URL")
-	cmd.MarkFlagRequired("app")
 	return cmd
 }
 

--- a/cmd/entity_delete.go
+++ b/cmd/entity_delete.go
@@ -18,7 +18,6 @@ import (
 func newEntityDeleteCmd() *cobra.Command {
 	var profile string
 	var server string
-	var app string
 
 	cmd := &cobra.Command{
 		Use:          "delete <name>",
@@ -26,14 +25,13 @@ func newEntityDeleteCmd() *cobra.Command {
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, _ := cmd.Parent().Flags().GetString("app")
 			return runEntityDelete(args[0], app, profile, server)
 		},
 	}
 
-	cmd.Flags().StringVar(&app, "app", "", "app name containing the entity (required)")
 	cmd.Flags().StringVar(&profile, "profile", "default", "credentials profile to use")
 	cmd.Flags().StringVar(&server, "server", defaultMetaServer, "Meta Server base URL")
-	cmd.MarkFlagRequired("app")
 	return cmd
 }
 

--- a/cmd/entity_list.go
+++ b/cmd/entity_list.go
@@ -20,7 +20,6 @@ import (
 func newEntityListCmd() *cobra.Command {
 	var profile string
 	var server string
-	var app string
 	var size int
 
 	cmd := &cobra.Command{
@@ -29,6 +28,7 @@ func newEntityListCmd() *cobra.Command {
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, _ := cmd.Parent().Flags().GetString("app")
 			entityName := ""
 			if len(args) == 1 {
 				entityName = args[0]
@@ -37,11 +37,9 @@ func newEntityListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&app, "app", "", "app name (required)")
 	cmd.Flags().StringVar(&profile, "profile", "default", "credentials profile to use")
 	cmd.Flags().StringVar(&server, "server", defaultMetaServer, "Meta Server base URL")
 	cmd.Flags().IntVar(&size, "size", 20, "number of entities per page")
-	cmd.MarkFlagRequired("app")
 	return cmd
 }
 


### PR DESCRIPTION
Make --app a required persistent flag on the entity command group, inherited by create/delete/list subcommands instead of duplicating the flag declaration on each subcommand.