### PR TITLE
Update agent UI stack guidance

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -8,7 +8,7 @@
 2. 根据用户的完整的需求场景进行业务建模, 生成对应的业务模型(app, entity, field, relation) 等 DSL, 保存到 @apps/dsl/ 目录下面.
 3. 将前面的 DSL 通过 makecli apply 到 make 开发平台上.
 4. 根据前面需求抽象定义后端接口沉淀到 @apps/doc/api.md 文件里面, 然后实现对应的业务逻辑实现对 make 平台的数据的 CRUD-LS 操作, make 的 API 文档可以参考 makedsl skill.
-5. 根据前面需求和刚才定义的 @apps/docs/api.md 文件, 实现前端UI, 交互, 动画等功能.
+5. 根据前面需求和刚才定义的 @apps/docs/api.md 文件, 实现前端UI, 交互, 动画等功能. UI 必须优先遵循 makeui skill；默认使用 React + Vite + React Router，除非用户明确要求且项目已支持其他前端栈。Make record list/table 必须通过 canvas-table-integration skill 接入 @qfei-design/canvas-table.
 6. 完成 @apps/README.md 包括: 简单项目说明, 如何启动ui 和 service.
 </implement_workflow>
 
@@ -17,10 +17,16 @@
 </update_workflow>
 
 <require_skills>
-install makedsl and makecli skill
+install make platform skills
 ```
 npx skills add qfeius/make-platform-skills --all -y
 ```
+
+必须安装并使用:
+- makedsl: 业务建模和 DSL 生成
+- makecli: apply / diff / schema / record 等 Make CLI 操作
+- makeui: apps/ui 前端 UI 设计和代码生成
+- canvas-table-integration: Make record list/table 和 cell editing
 </require_skills>
 
 <structure>
@@ -33,7 +39,7 @@ npx skills add qfeius/make-platform-skills --all -y
 ├── docs/
 ├── apps
     ├── README.md
-    ├── ui        (Next.js frontend)
+    ├── ui        (React + Vite + React Router frontend, follow makeui skill)
     │   ├── .env       (包含 SERVICE_BASE_URL 环境变量)
     ├── service       (express.js backend)
     │   ├── .env       (包含 MAKE_API_TOKEN 环境变量)
@@ -54,7 +60,7 @@ MAKE_API_TOKEN 访问 Make 平台需要的 token 统一抽取出来
 <dataflow>
 请求数据流
 ```
-ui (Next.js)
+ui (React + Vite + React Router)
          │
          │ 
          service (Express.js)


### PR DESCRIPTION
## Summary

本 PR 更新内置的 `agents/AGENTS.md` 模板，让 Make app 的前端实现默认遵循 `makeui` skill，而不是默认假设使用 Next.js。

## Changes

- 在 UI 实现流程中明确要求优先遵循 `makeui` skill。
- 将默认前端栈从 Next.js 调整为 React + Vite + React Router。
- 在 required skills 中补充 `makeui` 和 `canvas-table-integration`。
- 明确 Make record list/table 需要通过 `canvas-table-integration` 接入 `@qfei-design/canvas-table`。
- 同步更新模板中的 app 结构和数据流描述。

## Why

`make-platform-skills` 仓库里的 `makeui` skill 已经定义了 Make app 前端默认栈和 UI 规范，包括 React + Vite + React Router、Drawer 式创建/编辑/详情、动态对象路由，以及 canvas table 接入规则。

把 makecli 的 agent 模板对齐到 skill，可以避免继续在模板里写死 Next.js，也让 UI 规范后续主要由 skills 仓库维护。

## Validation

- 检查了 `agents/AGENTS.md` 的最终 diff。
- 执行了 `git diff --check -- agents/AGENTS.md`。
