### PR TITLE
Set UI dev server default port

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -58,6 +58,12 @@ MAKE_API_TOKEN 访问 Make 平台需要的 token 统一抽取出来
 这样后续部署的时候比较容易统一修改
 </structure>
 
+<dev_ports>
+- apps/ui 默认从 6000 端口启动.
+- Vite dev server 不要启用 strictPort; 如果 6000 被占用, 允许自动递增到 6001、6002 等可用端口.
+- apps/service 暂不强制指定端口, 沿用项目默认后端端口; UI 通过 SERVICE_BASE_URL 连接后端.
+</dev_ports>
+
 <dataflow>
 请求数据流
 ```
@@ -102,7 +108,7 @@ apps/package.json：
     "scripts": {
       "dev": "concurrently -n service,ui -c blue,green \"pnpm run app:service\" \"pnpm run app:ui\"",
       "app:service": "pnpm --filter service dev",
-      "app:ui": "pnpm --filter ui dev"
+      "app:ui": "pnpm --filter ui dev -- --host 0.0.0.0 --port 6000"
     },
     "devDependencies": {
       "concurrently": "^8.2.0"


### PR DESCRIPTION
## Summary

This PR updates the embedded `agents/AGENTS.md` template so generated Make app UI projects start the Vite dev server from port 6000 by default.

## Changes

- Adds a `dev_ports` section documenting that `apps/ui` starts from port 6000.
- Clarifies that Vite should not use `strictPort`, allowing automatic fallback to 6001, 6002, etc. when 6000 is occupied.
- Leaves the service/backend port behavior unchanged.
- Updates the generated `app:ui` script example to pass `--host 0.0.0.0 --port 6000`.

## Why

The previous Vite default port, 5173, is easy to collide with other local frontend projects. Starting generated Make app UI projects from 6000 gives them a more predictable local port range while still allowing Vite to automatically find the next available port.

## Validation

- Ran `git diff --check -- agents/AGENTS.md`.
