### PR TITLE
feat(version): add 'version list' to list historical GitHub releases

### DIFF
--- a/cmd/CLAUDE.md
+++ b/cmd/CLAUDE.md
@@ -19,8 +19,10 @@
 
 ## 成员清单
 root.go:             根命令入口，挂载所有子命令（含 schema），对外暴露 Execute(version, date)；定义全局 PersistentFlag --profile / --server-url / --debug，分别绑定全局变量 Profile / ServerURL / DebugMode
-version.go:          version 子命令，格式化版本输出（参考 GitHub CLI 模式）
+version.go:          version 子命令组，默认 Run 打印当前版本（参考 GitHub CLI 模式），挂载 list 子命令
 version_test.go:     覆盖 formatVersion / changelogURL 的纯函数测试
+version_list.go:     version list 子命令，调 internal/update.ListReleases 拉取 GitHub 最近 N 条 release，tablewriter 输出 CURRENT/VERSION/PUBLISHED/NAME/URL；CURRENT 列对比 build.Version 标记当前安装版本；支持 --limit（默认20，1-100）/ --output（table|json）
+version_list_test.go: 覆盖 runVersionList 的单元测试（table 渲染 / CURRENT 标记 / JSON 输出去除 assets / 空列表 / 非法 limit / 非法 output / API 错误 / 空 Name 回退 / DEV 不打标记），用 httptest 隔离网络
 configure.go:        configure 命令组（无本地标志，复用全局 --profile），默认行为等同 token 子命令；子命令: token（交互写 ~/.make/credentials）/ config（交互写 ~/.make/config）/ set（直接写单个 key）/ get（读取单个 key）/ verify（在线验证 token）；validateConfigKey 校验合法 key 集合
 configure_test.go:   覆盖 mask / validateJWT / validateConfigKey 的纯函数测试
 configure_verify.go:     configure verify 子命令，加载 credentials + config，JWT 格式校验后调 ListApps 在线验证 token；输出 verifyResult（profile/valid/token/server_url/tenant_id/operator_id/message）；支持 --output table|json；valid=false 时 exit 1

--- a/cmd/app_init_test.go
+++ b/cmd/app_init_test.go
@@ -8,6 +8,7 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,7 +49,7 @@ func TestRunAppInit(t *testing.T) {
 		for _, name := range []string{"CLAUDE.md", "AGENTS.md"} {
 			want, _ := agents.Templates.ReadFile(name)
 			got, _ := os.ReadFile(filepath.Join(dir, name))
-			if string(got) != string(want) {
+			if !bytes.Equal(got, want) {
 				t.Errorf("%s content mismatch", name)
 			}
 		}

--- a/cmd/configure_verify.go
+++ b/cmd/configure_verify.go
@@ -78,7 +78,7 @@ func runConfigureVerify(output string) (*verifyResult, error) {
 	p, ok := creds[Profile]
 	if !ok || p.AccessToken == "" {
 		result.Message = "token not configured"
-		outputVerifyResult(result, output)
+		outputVerifyResult(&result, output)
 		return &result, nil
 	}
 	result.Token = mask(p.AccessToken)
@@ -86,7 +86,7 @@ func runConfigureVerify(output string) (*verifyResult, error) {
 	// JWT 格式校验
 	if err := validateJWT(p.AccessToken); err != nil {
 		result.Message = "token invalid (malformed JWT)"
-		outputVerifyResult(result, output)
+		outputVerifyResult(&result, output)
 		return &result, nil
 	}
 
@@ -110,22 +110,23 @@ func runConfigureVerify(output string) (*verifyResult, error) {
 	_, _, err = client.ListApps(1, 1, nil)
 	if err != nil {
 		result.Message = fmt.Sprintf("token invalid (%s)", err)
-		outputVerifyResult(result, output)
+		outputVerifyResult(&result, output)
 		return &result, nil
 	}
 
 	result.Valid = true
 	result.Message = "ok"
-	outputVerifyResult(result, output)
+	outputVerifyResult(&result, output)
 	return &result, nil
 }
 
-func outputVerifyResult(r verifyResult, output string) {
-	if output == outputJSON {
+func outputVerifyResult(r *verifyResult, output string) {
+	switch {
+	case output == outputJSON:
 		_ = writeJSON(r)
-	} else if r.Valid {
+	case r.Valid:
 		fmt.Printf("Profile [%s]: ok\n", r.Profile)
-	} else {
+	default:
 		fmt.Printf("Profile [%s]: %s\n", r.Profile, r.Message)
 		fmt.Fprintf(os.Stderr, "\nRun \"makecli configure --profile %s\" to set access token.\n", r.Profile)
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,7 +1,7 @@
 /**
  * [INPUT]: 依赖 github.com/spf13/cobra、fmt、regexp、strings
  * [OUTPUT]: 对外提供 newVersionCmd 函数
- * [POS]: cmd 模块的 version 子命令，参考 GitHub CLI 的 pkg/cmd/version/version.go 实现
+ * [POS]: cmd 模块的 version 子命令，挂载 list 子命令；默认 Run 打印当前版本（参考 GitHub CLI 模式）
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -16,13 +16,15 @@ import (
 )
 
 func newVersionCmd(version, buildDate string) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Print(formatVersion(version, buildDate))
 		},
 	}
+	cmd.AddCommand(newVersionListCmd())
+	return cmd
 }
 
 // formatVersion 生成版本输出字符串，格式参考 GitHub CLI

--- a/cmd/version_list.go
+++ b/cmd/version_list.go
@@ -25,7 +25,7 @@ func newVersionListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List historical releases from GitHub",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVersionList(cmd, limit, output)
+			return runVersionList(limit, output)
 		},
 	}
 	cmd.Flags().IntVar(&limit, "limit", 20, "number of releases to fetch (1-100)")
@@ -33,7 +33,7 @@ func newVersionListCmd() *cobra.Command {
 	return cmd
 }
 
-func runVersionList(_ *cobra.Command, limit int, output string) error {
+func runVersionList(limit int, output string) error {
 	if limit < 1 || limit > 100 {
 		return fmt.Errorf("limit must be between 1 and 100")
 	}

--- a/cmd/version_list.go
+++ b/cmd/version_list.go
@@ -30,7 +30,7 @@ func newVersionListCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&limit, "limit", 20, "number of releases to fetch (1-100)")
-	cmd.Flags().StringVar(&output, "output", outputTable, "output format: table|json")
+	cmd.Flags().StringVar(&output, "output", outputTable, "output format (table|json)")
 	return cmd
 }
 

--- a/cmd/version_list.go
+++ b/cmd/version_list.go
@@ -1,0 +1,102 @@
+/**
+ * [INPUT]: 依赖 cmd/output（writeJSON / validateOutputFormat / outputTable / outputJSON）、internal/update（ListReleases）、internal/build（Version）、fmt、os、strings、github.com/olekukonko/tablewriter、github.com/spf13/cobra
+ * [OUTPUT]: 对外提供 newVersionListCmd 函数（包内）
+ * [POS]: cmd 模块 version 子命令下的 list 子命令，列出 GitHub 上的历史 release
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/qfeius/makecli/internal/build"
+	"github.com/qfeius/makecli/internal/update"
+	"github.com/spf13/cobra"
+)
+
+func newVersionListCmd() *cobra.Command {
+	var limit int
+	var output string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List historical releases from GitHub",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersionList(cmd, limit, output)
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 20, "number of releases to fetch (1-100)")
+	cmd.Flags().StringVar(&output, "output", outputTable, "output format: table|json")
+	return cmd
+}
+
+func runVersionList(_ *cobra.Command, limit int, output string) error {
+	if limit < 1 || limit > 100 {
+		return fmt.Errorf("limit must be between 1 and 100")
+	}
+	if err := validateOutputFormat(output); err != nil {
+		return err
+	}
+
+	releases, err := update.ListReleases(limit)
+	if err != nil {
+		return err
+	}
+
+	if output == outputJSON {
+		return writeJSON(toReleaseJSONView(releases))
+	}
+	return renderReleaseTable(releases, build.Version)
+}
+
+type releaseJSONView struct {
+	TagName     string `json:"tag_name"`
+	Name        string `json:"name"`
+	PublishedAt string `json:"published_at"`
+	Prerelease  bool   `json:"prerelease"`
+	HTMLURL     string `json:"html_url"`
+}
+
+func toReleaseJSONView(releases []update.Release) []releaseJSONView {
+	out := make([]releaseJSONView, len(releases))
+	for i, r := range releases {
+		out[i] = releaseJSONView{
+			TagName:     r.TagName,
+			Name:        r.Name,
+			PublishedAt: r.PublishedAt,
+			Prerelease:  r.Prerelease,
+			HTMLURL:     r.HTMLURL,
+		}
+	}
+	return out
+}
+
+func renderReleaseTable(releases []update.Release, currentVersion string) error {
+	if len(releases) == 0 {
+		fmt.Println("No releases found.")
+		return nil
+	}
+
+	currentTag := strings.TrimPrefix(currentVersion, "v")
+	rows := make([][]string, len(releases))
+	for i, r := range releases {
+		marker := ""
+		if strings.TrimPrefix(r.TagName, "v") == currentTag && currentTag != "" && currentTag != "DEV" {
+			marker = "*"
+		}
+		name := r.Name
+		if name == "" {
+			name = r.TagName
+		}
+		rows[i] = []string{marker, r.TagName, r.PublishedAt, name, r.HTMLURL}
+	}
+
+	table := tablewriter.NewTable(os.Stdout)
+	table.Header("CURRENT", "VERSION", "PUBLISHED", "NAME", "URL")
+	_ = table.Bulk(rows)
+	_ = table.Render()
+	return nil
+}

--- a/cmd/version_list.go
+++ b/cmd/version_list.go
@@ -22,8 +22,9 @@ func newVersionListCmd() *cobra.Command {
 	var limit int
 	var output string
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List historical releases from GitHub",
+		Use:          "list",
+		Short:        "List historical releases from GitHub",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVersionList(limit, output)
 		},

--- a/cmd/version_list_test.go
+++ b/cmd/version_list_test.go
@@ -43,7 +43,7 @@ func TestRunVersionList_Table(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(t, func() {
-		if err := runVersionList(nil, 20, "table"); err != nil {
+		if err := runVersionList(20, "table"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -67,7 +67,7 @@ func TestRunVersionList_TableMarksCurrent(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(t, func() {
-		if err := runVersionList(nil, 20, "table"); err != nil {
+		if err := runVersionList(20, "table"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -97,7 +97,7 @@ func TestRunVersionList_JSON(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(t, func() {
-		if err := runVersionList(nil, 20, "json"); err != nil {
+		if err := runVersionList(20, "json"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -119,7 +119,7 @@ func TestRunVersionList_Empty(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(t, func() {
-		if err := runVersionList(nil, 20, "table"); err != nil {
+		if err := runVersionList(20, "table"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -131,14 +131,14 @@ func TestRunVersionList_Empty(t *testing.T) {
 
 func TestRunVersionList_InvalidLimit(t *testing.T) {
 	for _, lim := range []int{0, -1, 101, 1000} {
-		if err := runVersionList(nil, lim, "table"); err == nil {
+		if err := runVersionList(lim, "table"); err == nil {
 			t.Errorf("expected error for limit=%d", lim)
 		}
 	}
 }
 
 func TestRunVersionList_InvalidOutput(t *testing.T) {
-	if err := runVersionList(nil, 20, "xml"); err == nil {
+	if err := runVersionList(20, "xml"); err == nil {
 		t.Fatal("expected error for output=xml")
 	}
 }
@@ -147,7 +147,49 @@ func TestRunVersionList_APIError(t *testing.T) {
 	cleanup := mockReleasesServer(t, http.StatusInternalServerError, nil)
 	defer cleanup()
 
-	if err := runVersionList(nil, 20, "table"); err == nil {
+	if err := runVersionList(20, "table"); err == nil {
 		t.Fatal("expected error for HTTP 500")
+	}
+}
+
+func TestRunVersionList_TableEmptyNameFallsBackToTag(t *testing.T) {
+	cleanup := mockReleasesServer(t, 0, []update.Release{
+		{TagName: "v1.2.3", Name: "", PublishedAt: "2026-05-10T08:12:00Z", HTMLURL: "https://example.com/r/1.2.3"},
+	})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(20, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// 当 Name 为空时，应使用 TagName 填充 NAME 列。
+	// v1.2.3 同时是 VERSION 与 NAME 列的值；统计该 token 出现次数应 >= 2。
+	if strings.Count(out, "v1.2.3") < 2 {
+		t.Errorf("expected v1.2.3 to appear in both VERSION and NAME columns when Name is empty, got:\n%s", out)
+	}
+}
+
+func TestRunVersionList_TableDevVersionNoMarker(t *testing.T) {
+	oldVersion := build.Version
+	build.Version = "DEV"
+	defer func() { build.Version = oldVersion }()
+
+	cleanup := mockReleasesServer(t, 0, []update.Release{
+		{TagName: "v1.2.3", Name: "fix", PublishedAt: "2026-05-10T08:12:00Z", HTMLURL: "https://example.com/r/1.2.3"},
+		{TagName: "v1.2.2", Name: "perf", PublishedAt: "2026-05-01T03:55:11Z", HTMLURL: "https://example.com/r/1.2.2"},
+	})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(20, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// DEV 版本不应在任何行打 * 标记
+	if strings.Contains(out, "*") {
+		t.Errorf("DEV build.Version should not produce any * marker, got:\n%s", out)
 	}
 }

--- a/cmd/version_list_test.go
+++ b/cmd/version_list_test.go
@@ -1,0 +1,153 @@
+/**
+ * [INPUT]: 依赖 cmd 包内的 runVersionList 与 internal/update 的 apiBaseURL
+ * [OUTPUT]: 覆盖 version list 子命令的单元测试
+ * [POS]: cmd 模块 version_list.go 的配套测试
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qfeius/makecli/internal/build"
+	"github.com/qfeius/makecli/internal/update"
+)
+
+func mockReleasesServer(t *testing.T, status int, body any) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if status != 0 {
+			w.WriteHeader(status)
+		}
+		if body != nil {
+			_ = json.NewEncoder(w).Encode(body)
+		}
+	}))
+	old := update.SetAPIBaseURLForTest(srv.URL)
+	return func() {
+		update.SetAPIBaseURLForTest(old)
+		srv.Close()
+	}
+}
+
+func TestRunVersionList_Table(t *testing.T) {
+	cleanup := mockReleasesServer(t, 0, []update.Release{
+		{TagName: "v1.2.3", Name: "v1.2.3 - fix", PublishedAt: "2026-05-10T08:12:00Z", HTMLURL: "https://example.com/r/1.2.3"},
+		{TagName: "v1.2.2", Name: "v1.2.2 - perf", PublishedAt: "2026-05-01T03:55:11Z", HTMLURL: "https://example.com/r/1.2.2"},
+	})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(nil, 20, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, want := range []string{"VERSION", "PUBLISHED", "NAME", "URL", "v1.2.3", "v1.2.2", "v1.2.3 - fix"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestRunVersionList_TableMarksCurrent(t *testing.T) {
+	oldVersion := build.Version
+	build.Version = "1.2.3"
+	defer func() { build.Version = oldVersion }()
+
+	cleanup := mockReleasesServer(t, 0, []update.Release{
+		{TagName: "v1.2.3", Name: "current", PublishedAt: "2026-05-10T08:12:00Z", HTMLURL: "https://example.com/r/1.2.3"},
+		{TagName: "v1.2.2", Name: "older", PublishedAt: "2026-05-01T03:55:11Z", HTMLURL: "https://example.com/r/1.2.2"},
+	})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(nil, 20, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	lines := strings.Split(out, "\n")
+	var currentLine, olderLine string
+	for _, ln := range lines {
+		if strings.Contains(ln, "v1.2.3") {
+			currentLine = ln
+		}
+		if strings.Contains(ln, "v1.2.2") {
+			olderLine = ln
+		}
+	}
+	if !strings.Contains(currentLine, "*") {
+		t.Errorf("expected v1.2.3 row to contain *, got %q", currentLine)
+	}
+	if strings.Contains(olderLine, "*") {
+		t.Errorf("expected v1.2.2 row to not contain *, got %q", olderLine)
+	}
+}
+
+func TestRunVersionList_JSON(t *testing.T) {
+	cleanup := mockReleasesServer(t, 0, []update.Release{
+		{TagName: "v1.2.3", Name: "fix", PublishedAt: "2026-05-10T08:12:00Z", Prerelease: false, HTMLURL: "https://example.com/r/1.2.3"},
+	})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(nil, 20, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out)
+	}
+	if len(got) != 1 || got[0]["tag_name"] != "v1.2.3" {
+		t.Fatalf("unexpected JSON: %+v", got)
+	}
+	if _, ok := got[0]["assets"]; ok {
+		t.Errorf("assets should not appear in JSON output, got %+v", got[0])
+	}
+}
+
+func TestRunVersionList_Empty(t *testing.T) {
+	cleanup := mockReleasesServer(t, 0, []update.Release{})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(nil, 20, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No releases found.") {
+		t.Errorf("expected 'No releases found.' in output, got %q", out)
+	}
+}
+
+func TestRunVersionList_InvalidLimit(t *testing.T) {
+	for _, lim := range []int{0, -1, 101, 1000} {
+		if err := runVersionList(nil, lim, "table"); err == nil {
+			t.Errorf("expected error for limit=%d", lim)
+		}
+	}
+}
+
+func TestRunVersionList_InvalidOutput(t *testing.T) {
+	if err := runVersionList(nil, 20, "xml"); err == nil {
+		t.Fatal("expected error for output=xml")
+	}
+}
+
+func TestRunVersionList_APIError(t *testing.T) {
+	cleanup := mockReleasesServer(t, http.StatusInternalServerError, nil)
+	defer cleanup()
+
+	if err := runVersionList(nil, 20, "table"); err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}

--- a/docs/superpowers/plans/2026-05-18-version-list.md
+++ b/docs/superpowers/plans/2026-05-18-version-list.md
@@ -1,0 +1,632 @@
+# makecli version list Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `makecli version list` subcommand that lists historical GitHub releases as a tablewriter table, with `--limit` and `--output` flags.
+
+**Architecture:** Extend `internal/update` with `ListReleases(limit int)` that calls GitHub Releases API. Refactor `cmd/version.go` to host a `list` subcommand while preserving its default `Run`. Add `cmd/version_list.go` for the new command. Output style mirrors `app list`.
+
+**Tech Stack:** Go, `github.com/spf13/cobra`, `github.com/olekukonko/tablewriter`, `net/http`, `encoding/json`, `net/http/httptest` for tests.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-18-version-list-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `internal/update/update.go` — extend `Release` struct, add `ListReleases(limit int)`
+- `internal/update/update_test.go` — tests for `ListReleases`
+- `internal/update/CLAUDE.md` — L2 update
+- `cmd/version.go` — refactor `newVersionCmd` to mount `list` subcommand
+- `cmd/CLAUDE.md` — L2 update
+
+**Create:**
+- `cmd/version_list.go` — new subcommand implementation
+- `cmd/version_list_test.go` — tests for the new subcommand
+
+---
+
+## Task 1: Extend `Release` struct in `internal/update`
+
+**Files:**
+- Modify: `internal/update/update.go` (struct definition near top of file)
+
+**Why:** `ListReleases` callers need `Name`, `PublishedAt`, `Prerelease`, `HTMLURL`. These are GitHub API fields not currently captured. Tests in Task 2 will assert them.
+
+- [ ] **Step 1: Extend Release struct**
+
+In `internal/update/update.go`, replace the existing `Release` struct with:
+
+```go
+// Release 表示 GitHub Releases API 返回的版本
+type Release struct {
+	TagName     string  `json:"tag_name"`
+	Name        string  `json:"name"`
+	PublishedAt string  `json:"published_at"`
+	Prerelease  bool    `json:"prerelease"`
+	HTMLURL     string  `json:"html_url"`
+	Assets      []Asset `json:"assets"`
+}
+```
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+Run: `make test`
+Expected: PASS — `CheckLatest` and `Apply` paths only use `TagName` and `Assets`, new fields default to zero values.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/update/update.go
+git commit -m "refactor(update): extend Release with name/published_at/prerelease/html_url"
+```
+
+---
+
+## Task 2: Add `ListReleases` with TDD
+
+**Files:**
+- Modify: `internal/update/update_test.go`
+- Modify: `internal/update/update.go`
+
+- [ ] **Step 1: Write failing tests for `ListReleases`**
+
+Append to `internal/update/update_test.go`:
+
+```go
+// -----------------------------------------------------------------------
+// ListReleases 测试
+// -----------------------------------------------------------------------
+
+func TestListReleases_Success(t *testing.T) {
+	releases := []Release{
+		{TagName: "v1.2.3", Name: "v1.2.3 - fix", PublishedAt: "2026-05-10T08:12:00Z", Prerelease: false, HTMLURL: "https://example.com/r/1.2.3"},
+		{TagName: "v1.2.2", Name: "v1.2.2 - perf", PublishedAt: "2026-05-01T03:55:11Z", Prerelease: true, HTMLURL: "https://example.com/r/1.2.2"},
+	}
+
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	got, err := ListReleases(20)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d releases, want 2", len(got))
+	}
+	if got[0].TagName != "v1.2.3" || got[0].Name != "v1.2.3 - fix" {
+		t.Errorf("first release mismatch: %+v", got[0])
+	}
+	if got[1].Prerelease != true {
+		t.Errorf("expected second release prerelease=true, got %+v", got[1])
+	}
+	if gotQuery != "per_page=20" {
+		t.Errorf("expected query per_page=20, got %q", gotQuery)
+	}
+}
+
+func TestListReleases_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	_, err := ListReleases(20)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}
+
+func TestListReleases_ParseError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	_, err := ListReleases(20)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/update/ -run TestListReleases -v`
+Expected: FAIL with "undefined: ListReleases"
+
+- [ ] **Step 3: Implement `ListReleases`**
+
+In `internal/update/update.go`, add this function under the `// 公开 API` section, after `CheckLatest`:
+
+```go
+// ListReleases 拉取最近 limit 条 release（按 created_at 倒序）
+func ListReleases(limit int) ([]Release, error) {
+	url := fmt.Sprintf("%s/repos/qfeius/makecli/releases?per_page=%d", apiBaseURL, limit)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list releases: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list releases: HTTP %d", resp.StatusCode)
+	}
+
+	var releases []Release
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("failed to parse releases: %w", err)
+	}
+
+	return releases, nil
+}
+```
+
+- [ ] **Step 4: Update file header L3 contract**
+
+In `internal/update/update.go`, update the `[OUTPUT]` line of the file header comment to include `ListReleases`:
+
+```go
+ * [OUTPUT]: 对外提供 CheckLatest / ListReleases / Apply 函数、Release / Asset 结构体
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `make test`
+Expected: PASS — all `internal/update` tests including the 3 new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/update/update.go internal/update/update_test.go
+git commit -m "feat(update): add ListReleases for GitHub releases API"
+```
+
+---
+
+## Task 3: Refactor `cmd/version.go` to host `list` subcommand
+
+**Files:**
+- Modify: `cmd/version.go`
+
+**Why:** Cobra commands can have both `Run` and child commands. We preserve `makecli version` behavior while enabling `makecli version list`.
+
+- [ ] **Step 1: Modify `newVersionCmd` to mount subcommand**
+
+Replace `newVersionCmd` in `cmd/version.go` with:
+
+```go
+func newVersionCmd(version, buildDate string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Print(formatVersion(version, buildDate))
+		},
+	}
+	cmd.AddCommand(newVersionListCmd())
+	return cmd
+}
+```
+
+`formatVersion` and `changelogURL` stay unchanged.
+
+- [ ] **Step 2: Update file header L3 contract**
+
+In `cmd/version.go`, update the `[POS]` line:
+
+```go
+ * [POS]: cmd 模块的 version 子命令，挂载 list 子命令；默认 Run 打印当前版本（参考 GitHub CLI 模式）
+```
+
+- [ ] **Step 3: Verify compile (will fail until Task 4 adds `newVersionListCmd`)**
+
+Run: `go build ./...`
+Expected: FAIL with "undefined: newVersionListCmd" — that's expected, we'll fix in Task 4. Do NOT commit yet; combine with Task 4 implementation.
+
+---
+
+## Task 4: Implement `cmd/version_list.go` with TDD
+
+**Files:**
+- Create: `cmd/version_list_test.go`
+- Create: `cmd/version_list.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cmd/version_list_test.go`:
+
+```go
+/**
+ * [INPUT]: 依赖 cmd 包内的 runVersionList 与 internal/update 的 apiBaseURL
+ * [OUTPUT]: 覆盖 version list 子命令的单元测试
+ * [POS]: cmd 模块 version_list.go 的配套测试
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qfeius/makecli/internal/build"
+	"github.com/qfeius/makecli/internal/update"
+)
+
+func mockReleasesServer(t *testing.T, status int, body any) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if status != 0 {
+			w.WriteHeader(status)
+		}
+		if body != nil {
+			_ = json.NewEncoder(w).Encode(body)
+		}
+	}))
+	old := update.SetAPIBaseURLForTest(srv.URL)
+	return func() {
+		update.SetAPIBaseURLForTest(old)
+		srv.Close()
+	}
+}
+
+func TestRunVersionList_Table(t *testing.T) {
+	cleanup := mockReleasesServer(t, 0, []update.Release{
+		{TagName: "v1.2.3", Name: "v1.2.3 - fix", PublishedAt: "2026-05-10T08:12:00Z", HTMLURL: "https://example.com/r/1.2.3"},
+		{TagName: "v1.2.2", Name: "v1.2.2 - perf", PublishedAt: "2026-05-01T03:55:11Z", HTMLURL: "https://example.com/r/1.2.2"},
+	})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(nil, 20, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, want := range []string{"VERSION", "PUBLISHED", "NAME", "URL", "v1.2.3", "v1.2.2", "v1.2.3 - fix"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestRunVersionList_TableMarksCurrent(t *testing.T) {
+	oldVersion := build.Version
+	build.Version = "1.2.3"
+	defer func() { build.Version = oldVersion }()
+
+	cleanup := mockReleasesServer(t, 0, []update.Release{
+		{TagName: "v1.2.3", Name: "current", PublishedAt: "2026-05-10T08:12:00Z", HTMLURL: "https://example.com/r/1.2.3"},
+		{TagName: "v1.2.2", Name: "older", PublishedAt: "2026-05-01T03:55:11Z", HTMLURL: "https://example.com/r/1.2.2"},
+	})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(nil, 20, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	lines := strings.Split(out, "\n")
+	var currentLine, olderLine string
+	for _, ln := range lines {
+		if strings.Contains(ln, "v1.2.3") {
+			currentLine = ln
+		}
+		if strings.Contains(ln, "v1.2.2") {
+			olderLine = ln
+		}
+	}
+	if !strings.Contains(currentLine, "*") {
+		t.Errorf("expected v1.2.3 row to contain *, got %q", currentLine)
+	}
+	if strings.Contains(olderLine, "*") {
+		t.Errorf("expected v1.2.2 row to not contain *, got %q", olderLine)
+	}
+}
+
+func TestRunVersionList_JSON(t *testing.T) {
+	cleanup := mockReleasesServer(t, 0, []update.Release{
+		{TagName: "v1.2.3", Name: "fix", PublishedAt: "2026-05-10T08:12:00Z", Prerelease: false, HTMLURL: "https://example.com/r/1.2.3"},
+	})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(nil, 20, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out)
+	}
+	if len(got) != 1 || got[0]["tag_name"] != "v1.2.3" {
+		t.Fatalf("unexpected JSON: %+v", got)
+	}
+	if _, ok := got[0]["assets"]; ok {
+		t.Errorf("assets should not appear in JSON output, got %+v", got[0])
+	}
+}
+
+func TestRunVersionList_Empty(t *testing.T) {
+	cleanup := mockReleasesServer(t, 0, []update.Release{})
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := runVersionList(nil, 20, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No releases found.") {
+		t.Errorf("expected 'No releases found.' in output, got %q", out)
+	}
+}
+
+func TestRunVersionList_InvalidLimit(t *testing.T) {
+	for _, lim := range []int{0, -1, 101, 1000} {
+		if err := runVersionList(nil, lim, "table"); err == nil {
+			t.Errorf("expected error for limit=%d", lim)
+		}
+	}
+}
+
+func TestRunVersionList_InvalidOutput(t *testing.T) {
+	if err := runVersionList(nil, 20, "xml"); err == nil {
+		t.Fatal("expected error for output=xml")
+	}
+}
+
+func TestRunVersionList_APIError(t *testing.T) {
+	cleanup := mockReleasesServer(t, http.StatusInternalServerError, nil)
+	defer cleanup()
+
+	if err := runVersionList(nil, 20, "table"); err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}
+```
+
+The tests reference `update.SetAPIBaseURLForTest`, which doesn't exist yet — we add it in Step 2 below.
+
+- [ ] **Step 2: Add test helper to `internal/update`**
+
+Append to `internal/update/update.go` (at end of file):
+
+```go
+// SetAPIBaseURLForTest 替换 GitHub API 基础 URL，返回原值用于恢复。仅供测试使用。
+func SetAPIBaseURLForTest(url string) string {
+	old := apiBaseURL
+	apiBaseURL = url
+	return old
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./cmd/ -run TestRunVersionList -v`
+Expected: FAIL with "undefined: runVersionList" and "undefined: newVersionListCmd".
+
+- [ ] **Step 4: Create `cmd/version_list.go`**
+
+Create `cmd/version_list.go`:
+
+```go
+/**
+ * [INPUT]: 依赖 cmd/output（writeJSON / validateOutputFormat / outputTable / outputJSON）、internal/update（ListReleases）、internal/build（Version）、fmt、os、strings、github.com/olekukonko/tablewriter、github.com/spf13/cobra
+ * [OUTPUT]: 对外提供 newVersionListCmd 函数（包内）
+ * [POS]: cmd 模块 version 子命令下的 list 子命令，列出 GitHub 上的历史 release
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/qfeius/makecli/internal/build"
+	"github.com/qfeius/makecli/internal/update"
+	"github.com/spf13/cobra"
+)
+
+func newVersionListCmd() *cobra.Command {
+	var limit int
+	var output string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List historical releases from GitHub",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersionList(cmd, limit, output)
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 20, "number of releases to fetch (1-100)")
+	cmd.Flags().StringVar(&output, "output", outputTable, "output format: table|json")
+	return cmd
+}
+
+func runVersionList(_ *cobra.Command, limit int, output string) error {
+	if limit < 1 || limit > 100 {
+		return fmt.Errorf("limit must be between 1 and 100")
+	}
+	if err := validateOutputFormat(output); err != nil {
+		return err
+	}
+
+	releases, err := update.ListReleases(limit)
+	if err != nil {
+		return err
+	}
+
+	if output == outputJSON {
+		return writeJSON(toReleaseJSONView(releases))
+	}
+	return renderReleaseTable(releases, build.Version)
+}
+
+type releaseJSONView struct {
+	TagName     string `json:"tag_name"`
+	Name        string `json:"name"`
+	PublishedAt string `json:"published_at"`
+	Prerelease  bool   `json:"prerelease"`
+	HTMLURL     string `json:"html_url"`
+}
+
+func toReleaseJSONView(releases []update.Release) []releaseJSONView {
+	out := make([]releaseJSONView, len(releases))
+	for i, r := range releases {
+		out[i] = releaseJSONView{
+			TagName:     r.TagName,
+			Name:        r.Name,
+			PublishedAt: r.PublishedAt,
+			Prerelease:  r.Prerelease,
+			HTMLURL:     r.HTMLURL,
+		}
+	}
+	return out
+}
+
+func renderReleaseTable(releases []update.Release, currentVersion string) error {
+	if len(releases) == 0 {
+		fmt.Println("No releases found.")
+		return nil
+	}
+
+	currentTag := strings.TrimPrefix(currentVersion, "v")
+	rows := make([][]string, len(releases))
+	for i, r := range releases {
+		marker := ""
+		if strings.TrimPrefix(r.TagName, "v") == currentTag && currentTag != "" && currentTag != "DEV" {
+			marker = "*"
+		}
+		name := r.Name
+		if name == "" {
+			name = r.TagName
+		}
+		rows[i] = []string{marker, r.TagName, r.PublishedAt, name, r.HTMLURL}
+	}
+
+	table := tablewriter.NewTable(os.Stdout)
+	table.Header("CURRENT", "VERSION", "PUBLISHED", "NAME", "URL")
+	_ = table.Bulk(rows)
+	_ = table.Render()
+	return nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `make test`
+Expected: PASS — all tests across the repo including the 7 new `TestRunVersionList_*` and 3 new `TestListReleases_*`.
+
+- [ ] **Step 6: Run vet and build**
+
+Run: `make vet && make build`
+Expected: both succeed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/version.go cmd/version_list.go cmd/version_list_test.go internal/update/update.go
+git commit -m "feat(version): add 'version list' subcommand to list GitHub releases"
+```
+
+---
+
+## Task 5: Update documentation (L2 maps)
+
+**Files:**
+- Modify: `cmd/CLAUDE.md`
+- Modify: `internal/update/CLAUDE.md`
+
+- [ ] **Step 1: Update `cmd/CLAUDE.md` member list**
+
+In `cmd/CLAUDE.md`, locate the `version.go:` line under `## 成员清单`. Replace it with:
+
+```
+version.go:          version 子命令组，默认 Run 打印当前版本（参考 GitHub CLI 模式），挂载 list 子命令
+version_test.go:     覆盖 formatVersion / changelogURL 的纯函数测试
+version_list.go:     version list 子命令，调 internal/update.ListReleases 拉取 GitHub 最近 N 条 release，tablewriter 输出 CURRENT/VERSION/PUBLISHED/NAME/URL；CURRENT 列对比 build.Version 标记当前安装版本；支持 --limit（默认20，1-100）/ --output（table|json）
+version_list_test.go: 覆盖 runVersionList 的单元测试（table 渲染 / CURRENT 标记 / JSON 输出去除 assets / 空列表 / 非法 limit / 非法 output / API 错误），用 httptest 隔离网络
+```
+
+- [ ] **Step 2: Update `internal/update/CLAUDE.md` member list**
+
+Replace the content under `## 成员清单` in `internal/update/CLAUDE.md` with:
+
+```
+update.go:      自更新引擎，CheckLatest 查询 GitHub latest release、ListReleases 拉取最近 N 条 release、Apply 下载→解压→原子替换；内部实现 isNewer（semver 比较，DEV 视为始终可更新）、download/extractBinary/replaceBinary 完整流水线；导出 SetAPIBaseURLForTest 供 cmd 层测试替换 API URL
+update_test.go: 覆盖 isNewer / assetName / findAsset / CheckLatest / ListReleases 的单元测试，用 httptest 隔离网络
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/CLAUDE.md internal/update/CLAUDE.md
+git commit -m "docs: sync L2 maps for version list subcommand"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+Expected: PASS — entire repo.
+
+- [ ] **Step 2: Static check**
+
+Run: `make vet`
+Expected: no warnings.
+
+- [ ] **Step 3: Build binary**
+
+Run: `make build`
+Expected: produces `bin/makecli`.
+
+- [ ] **Step 4: Smoke test the new command**
+
+Run: `./bin/makecli version`
+Expected: prints `makecli version DEV` + a changelog URL (unchanged behavior).
+
+Run: `./bin/makecli version list --limit 5`
+Expected: prints a tablewriter table with up to 5 historical releases. `CURRENT` column empty for DEV build. No errors.
+
+Run: `./bin/makecli version list --limit 3 --output json`
+Expected: JSON array of 3 releases with `tag_name`, `name`, `published_at`, `prerelease`, `html_url`. No `assets` field.
+
+Run: `./bin/makecli version list --limit 0`
+Expected: exits non-zero with `Error: limit must be between 1 and 100`.
+
+Run: `./bin/makecli version list --output xml`
+Expected: exits non-zero with `Error: unsupported output format "xml"...`.
+
+- [ ] **Step 5: No-op commit if verification reveals nothing**
+
+If the manual run uncovers issues, fix them as a new task. Otherwise, the previous commits already capture the work — no extra commit needed.

--- a/docs/superpowers/specs/2026-05-18-version-list-design.md
+++ b/docs/superpowers/specs/2026-05-18-version-list-design.md
@@ -1,0 +1,223 @@
+# makecli version list 命令设计
+
+## 概述
+
+为 `makecli version` 新增 `list` 子命令，列出 GitHub 上的历史 release。复用 `internal/update` 已有的 GitHub Releases 调用能力，输出风格与 `makecli app list` 对齐（tablewriter 边框表格 + `--output table|json` 双格式）。
+
+## 范围
+
+**包含：**
+- `internal/update`：扩展 `Release` 结构体新增 4 个字段，新增 `ListReleases(limit int)` 函数
+- `cmd/version.go`：保留 `formatVersion / changelogURL`，将 `newVersionCmd` 升级为「带默认 Run + 挂载子命令」的命令组
+- `cmd/version_list.go`：新增 `newVersionListCmd` 子命令 + `runVersionList` 实现
+- 测试：`cmd/version_list_test.go`、`internal/update/update_test.go` 增量
+- 文档：`cmd/CLAUDE.md`、`internal/update/CLAUDE.md`、对应文件头 L3 契约
+
+**不包含：**
+- 按平台过滤可用 asset（GitHub 公开数据，未来按需）
+- 离线缓存（每次实时拉取，GitHub API 公开端点无需鉴权）
+- 翻页（默认 20 条够用，limit 上限 100，超过则需另写 paginated 方案）
+
+## 命令行为
+
+```
+makecli version            # 行为不变：打印当前版本 + changelog 链接
+makecli version list       # 新增：列出最近 20 条 release
+```
+
+`version` 命令同时拥有 `Run` 和子命令，Cobra 在无子命令参数时执行 `Run`，传入 `list` 时走子命令。
+
+### Flag
+
+| Flag | 类型 | 默认 | 含义 |
+|------|------|------|------|
+| `--limit` | int | `20` | 拉取条数，必须在 [1, 100] 范围内（受 GitHub `per_page` 上限约束） |
+| `--output` | string | `table` | 输出格式，可选 `table` / `json` |
+
+不需要 `--profile` / `--server-url`，与 `update` 命令同 — 走 GitHub 公开 API。
+
+### 表格列
+
+```
+CURRENT  VERSION  PUBLISHED             NAME                   URL
+*        v1.2.3   2026-05-10T08:12:00Z  v1.2.3 - patch fix     https://github.com/qfeius/makecli/releases/tag/v1.2.3
+         v1.2.2   2026-05-01T03:55:11Z  v1.2.2 - perf          https://github.com/qfeius/makecli/releases/tag/v1.2.2
+```
+
+- `CURRENT`：tag 等于 `build.Version`（双方去前缀 `v`）时填 `*`，否则空
+- `VERSION`：原样取 `Release.TagName`（GitHub 返回带 `v` 前缀）
+- `PUBLISHED`：原样取 `Release.PublishedAt`（ISO8601），与 `app list` 的 `CREATED AT` 风格一致
+- `NAME`：取 `Release.Name`，空时回退 `tag_name`
+- `URL`：取 `Release.HTMLURL`
+
+渲染用 `tablewriter.NewTable(os.Stdout)` + `Header(...) + Bulk(rows) + Render()`，遵守 `cmd/CLAUDE.md` 表格约定。
+
+### JSON 输出
+
+```json
+[
+  {
+    "tag_name": "v1.2.3",
+    "name": "v1.2.3 - patch fix",
+    "published_at": "2026-05-10T08:12:00Z",
+    "prerelease": false,
+    "html_url": "https://github.com/qfeius/makecli/releases/tag/v1.2.3"
+  }
+]
+```
+
+不输出 `Assets` 字段（噪音；用户不需要从 `version list` 看到平台包）。
+
+## 数据层设计（`internal/update`）
+
+### Release 结构体扩展
+
+```go
+type Release struct {
+    TagName     string  `json:"tag_name"`
+    Name        string  `json:"name"`         // 新增
+    PublishedAt string  `json:"published_at"` // 新增
+    Prerelease  bool    `json:"prerelease"`   // 新增
+    HTMLURL     string  `json:"html_url"`     // 新增
+    Assets      []Asset `json:"assets"`
+}
+```
+
+向后兼容：新增字段不会破坏 `CheckLatest` 与 `Apply` 现有逻辑。
+
+### ListReleases 函数
+
+```go
+func ListReleases(limit int) ([]Release, error) {
+    url := fmt.Sprintf("%s/repos/qfeius/makecli/releases?per_page=%d", apiBaseURL, limit)
+    // GET → 200 → JSON decode → return
+    // 非 200 → return error
+}
+```
+
+- 走 `apiBaseURL`（测试可替换）
+- 错误处理对称于 `CheckLatest`：HTTP 错误带状态码、解析错误带原因
+
+## CLI 层设计（`cmd/version.go` 重构 + `cmd/version_list.go` 新增）
+
+### version.go 改造
+
+```go
+func newVersionCmd(version, buildDate string) *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "version",
+        Short: "Show version information",
+        Run: func(cmd *cobra.Command, args []string) {
+            fmt.Print(formatVersion(version, buildDate))
+        },
+    }
+    cmd.AddCommand(newVersionListCmd())
+    return cmd
+}
+```
+
+`formatVersion` / `changelogURL` 保持不变。
+
+### version_list.go 骨架
+
+```go
+func newVersionListCmd() *cobra.Command {
+    var limit int
+    var output string
+    cmd := &cobra.Command{
+        Use:   "list",
+        Short: "List historical releases from GitHub",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return runVersionList(cmd, limit, output)
+        },
+    }
+    cmd.Flags().IntVar(&limit, "limit", 20, "number of releases to fetch (1-100)")
+    cmd.Flags().StringVar(&output, "output", "table", "output format: table|json")
+    return cmd
+}
+
+func runVersionList(cmd *cobra.Command, limit int, output string) error {
+    if limit < 1 || limit > 100 {
+        return fmt.Errorf("limit must be between 1 and 100")
+    }
+    if err := validateOutputFormat(output); err != nil {
+        return err
+    }
+
+    releases, err := update.ListReleases(limit)
+    if err != nil {
+        return err
+    }
+
+    if output == outputJSON {
+        return writeJSON(toJSONView(releases))
+    }
+    return renderReleaseTable(releases, build.Version)
+}
+```
+
+`renderReleaseTable`：构造 5 列 rows，匹配 CURRENT 标记规则后调 `tablewriter` 渲染。
+`toJSONView`：将 `[]Release` 投影为去掉 Assets 的简化结构体切片。
+
+## 错误 & 边界
+
+| 场景 | 行为 |
+|------|------|
+| GitHub 网络失败 | 透传错误 |
+| GitHub 返回非 200 | 返回带状态码错误 |
+| `--limit < 1 \|\| > 100` | 返回 `limit must be between 1 and 100` |
+| `--output` 非法值 | 复用 `validateOutputFormat`，返回错误 |
+| 空列表 | table 模式打印 `No releases found.`，JSON 模式输出 `[]` |
+| 当前版本是 `DEV` | CURRENT 列全空（DEV 不会匹配任何 tag） |
+
+## 测试
+
+### `internal/update/update_test.go` 新增
+
+- `TestListReleases_Success`：httptest mock 返回 3 条 release，断言数量和字段
+- `TestListReleases_HTTPError`：500 错误路径
+- `TestListReleases_ParseError`：非法 JSON
+
+### `cmd/version_list_test.go` 新增
+
+- `TestRunVersionList_Table`：mock GitHub，验证 stdout 包含 VERSION/CURRENT 列与预期行
+- `TestRunVersionList_TableMarksCurrent`：mock 的某 tag 等于 build.Version，验证 `*` 出现在正确行
+- `TestRunVersionList_JSON`：验证 JSON 序列化正确、不含 Assets
+- `TestRunVersionList_Empty`：mock 返回空数组
+- `TestRunVersionList_InvalidLimit`：limit=0 和 limit=101 各一例
+- `TestRunVersionList_InvalidOutput`：output=xml
+- `TestRunVersionList_APIError`：GitHub 返回 500
+
+利用 `captureStdout`（来自 `stdout_test.go`）+ 替换 `apiBaseURL`，沿用 `update_test.go` 的隔离模式。
+
+## 文档更新
+
+### `cmd/CLAUDE.md`
+
+成员清单新增：
+```
+version_list.go:        version list 子命令，调 internal/update.ListReleases 拉取 GitHub 最近 N 条 release，tablewriter 输出 CURRENT/VERSION/PUBLISHED/NAME/URL；支持 --limit（默认20，1-100）/ --output（table|json）；CURRENT 列对比 build.Version 标记当前安装版本
+version_list_test.go:   覆盖 runVersionList 的单元测试（table/JSON/空列表/非法 limit/非法 output/API 错误/CURRENT 标记），用 httptest 隔离网络
+```
+
+`version.go` 描述更新为「挂载 list 子命令 + 默认 Run 打印当前版本」。
+
+### `internal/update/CLAUDE.md`
+
+`update.go` 描述新增 `ListReleases` 说明，`update_test.go` 描述新增对 `ListReleases` 的覆盖。
+
+### L3 文件头契约
+
+- `cmd/version.go` POS 更新为「version 子命令，挂载 list 子命令，默认 Run 打印当前版本」
+- `cmd/version_list.go` 新文件，添加完整 INPUT/OUTPUT/POS/PROTOCOL 头
+- `internal/update/update.go` OUTPUT 添加 `ListReleases`
+
+## 实现顺序（提示给后续 plan）
+
+1. 扩展 `Release` 结构体 + 实现 `ListReleases`
+2. `internal/update` 测试
+3. 重构 `version.go` 挂子命令
+4. 新增 `version_list.go`
+5. `cmd` 测试
+6. 文档（L1/L2/L3）同步
+7. `make test && make vet && make build` 整体验证

--- a/internal/update/CLAUDE.md
+++ b/internal/update/CLAUDE.md
@@ -2,7 +2,7 @@
 > L2 | 父级: /CLAUDE.md
 
 ## 成员清单
-update.go:      自更新引擎，CheckLatest 查询 GitHub latest release，Apply 下载→解压→原子替换；内部实现 isNewer（semver 比较，DEV 视为始终可更新）、download/extractBinary/replaceBinary 完整流水线
-update_test.go: 覆盖 isNewer / assetName / findAsset / CheckLatest 的单元测试，用 httptest 隔离网络
+update.go:      自更新引擎，CheckLatest 查询 GitHub latest release、ListReleases 拉取最近 N 条 release、Apply 下载→解压→原子替换；内部实现 isNewer（semver 比较，DEV 视为始终可更新）、download/extractBinary/replaceBinary 完整流水线；导出 SetAPIBaseURLForTest 供 cmd 层测试替换 API URL
+update_test.go: 覆盖 isNewer / assetName / findAsset / CheckLatest / ListReleases 的单元测试，用 httptest 隔离网络
 
 [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -306,6 +306,13 @@ func copyFile(src, dst string) error {
 	return err
 }
 
+// SetAPIBaseURLForTest 替换 GitHub API 基础 URL，返回原值用于恢复。仅供测试使用。
+func SetAPIBaseURLForTest(url string) string {
+	old := apiBaseURL
+	apiBaseURL = url
+	return old
+}
+
 // isNewer 使用 semver 比较版本，DEV 版本视为始终可更新
 func isNewer(current, remote string) bool {
 	remote = strings.TrimPrefix(remote, "v")

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 net/http、archive/tar、compress/gzip、encoding/json、github.com/Masterminds/semver/v3
- * [OUTPUT]: 对外提供 CheckLatest / Apply 函数、Release / Asset 结构体
+ * [OUTPUT]: 对外提供 CheckLatest / ListReleases / Apply 函数、Release / Asset 结构体
  * [POS]: internal/update 的核心引擎，被 cmd/update.go 消费
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -73,6 +73,28 @@ func CheckLatest(currentVersion string) (*Release, bool, error) {
 
 	newer := isNewer(currentVersion, release.TagName)
 	return &release, newer, nil
+}
+
+// ListReleases 拉取最近 limit 条 release（按 created_at 倒序）
+func ListReleases(limit int) ([]Release, error) {
+	url := fmt.Sprintf("%s/repos/qfeius/makecli/releases?per_page=%d", apiBaseURL, limit)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list releases: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list releases: HTTP %d", resp.StatusCode)
+	}
+
+	var releases []Release
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("failed to parse releases: %w", err)
+	}
+
+	return releases, nil
 }
 
 // Apply 下载指定 release 的 asset 并替换当前二进制

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -26,10 +26,14 @@ import (
 // 数据结构
 // -----------------------------------------------------------------------
 
-// Release 表示 GitHub Releases API 返回的最新版本
+// Release 表示 GitHub Releases API 返回的版本
 type Release struct {
-	TagName string  `json:"tag_name"`
-	Assets  []Asset `json:"assets"`
+	TagName     string  `json:"tag_name"`
+	Name        string  `json:"name"`
+	PublishedAt string  `json:"published_at"`
+	Prerelease  bool    `json:"prerelease"`
+	HTMLURL     string  `json:"html_url"`
+	Assets      []Asset `json:"assets"`
 }
 
 // Asset 表示 release 中的单个可下载文件

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -154,3 +154,74 @@ func TestCheckLatest_HTTPError(t *testing.T) {
 		t.Fatal("expected error for HTTP 500")
 	}
 }
+
+// -----------------------------------------------------------------------
+// ListReleases 测试
+// -----------------------------------------------------------------------
+
+func TestListReleases_Success(t *testing.T) {
+	releases := []Release{
+		{TagName: "v1.2.3", Name: "v1.2.3 - fix", PublishedAt: "2026-05-10T08:12:00Z", Prerelease: false, HTMLURL: "https://example.com/r/1.2.3"},
+		{TagName: "v1.2.2", Name: "v1.2.2 - perf", PublishedAt: "2026-05-01T03:55:11Z", Prerelease: true, HTMLURL: "https://example.com/r/1.2.2"},
+	}
+
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	got, err := ListReleases(20)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d releases, want 2", len(got))
+	}
+	if got[0].TagName != "v1.2.3" || got[0].Name != "v1.2.3 - fix" {
+		t.Errorf("first release mismatch: %+v", got[0])
+	}
+	if got[1].Prerelease != true {
+		t.Errorf("expected second release prerelease=true, got %+v", got[1])
+	}
+	if gotQuery != "per_page=20" {
+		t.Errorf("expected query per_page=20, got %q", gotQuery)
+	}
+}
+
+func TestListReleases_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	_, err := ListReleases(20)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}
+
+func TestListReleases_ParseError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	_, err := ListReleases(20)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}


### PR DESCRIPTION
## Summary

- 新增 `makecli version list` 子命令，按时间倒序列出 GitHub 上的历史 release，输出风格与 `app list` 对齐（tablewriter 边框 + `--output table|json`）
- 表格列：`CURRENT` / `VERSION` / `PUBLISHED` / `NAME` / `URL`，CURRENT 列用 `*` 标记当前安装版本（精准 tag 匹配，DEV/dirty build 不打标）
- `internal/update` 扩展 `Release` 结构体（Name/PublishedAt/Prerelease/HTMLURL）并新增 `ListReleases(limit int)`；`makecli version` 默认行为保持不变

## Test Plan

- [x] `make test` 全 pass（cmd 包新增 9 个 `TestRunVersionList_*` 测试，update 包新增 3 个 `TestListReleases_*` 测试）
- [x] `make vet` clean
- [x] `make build` 产出二进制
- [x] 手动 smoke：`makecli version`（不变）、`version list --limit 5`（table）、`version list --limit 2 --output json`（无 assets 字段）、`version list --limit 0`（错误退出 1）、`version list --output xml`（错误退出 1）

## Reference

- Spec: \`docs/superpowers/specs/2026-05-18-version-list-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-18-version-list.md\`