### PR TITLE
feat(update): accept [version] arg with --force for downgrades

### DIFF
--- a/cmd/CLAUDE.md
+++ b/cmd/CLAUDE.md
@@ -72,7 +72,8 @@ diff_test.go:        覆盖 diff 子命令核心逻辑的单元测试（computeD
 schema.go:           schema 顶级子命令，调用 MakeService.GetResource 获取指定 App 的聚合 Schema（App + Entities + Relations），JSON 输出；支持 --app（必选）/ --profile
 schema_test.go:      覆盖 runSchema 的单元测试（成功/无凭证/API错误/未知profile），用 httptest 隔离网络
 output.go:           list 命令通用输出辅助（table|json 格式校验 + JSON 编码），被 app list / entity list / relation list / record list / record get 复用
-update.go:           update 子命令，从 GitHub Releases 自更新二进制；直接 import internal/build 读取版本，委托 internal/update 执行检查和替换
+update.go:           update 子命令，支持 [version] 位置参数（v0.2.0 或 0.2.0）和 --force 标志；无 arg 走 CheckLatest 流程，指定版本走 GetRelease；CompareVersions 决定 upgrade/same/downgrade 分支，降级需 --force；DEV 版本跳过比较；applyFunc 包级变量便于测试打桩
+update_test.go:      覆盖 runUpdate 的单元测试（latest 已到位/有更新、specific 升级/同版本/降级拒绝/--force 降级/规范化无 v 前缀/非法 semver/tag 不存在/DEV 跳过比较），applyFunc 打桩避免真实替换二进制
 integration.go:           integration 命令组，挂载 ocr 子命令；预留扩展点供未来其它 integration（translate / asr / embed 等）
 integration_ocr.go:       integration ocr 子命令，校验文件后缀（.pdf/.ofd/.png/.jpg/.jpeg）后通过 newClientFromProfile 上传，调用 api.OCR；renderOCRTable 风格对齐 entity list <name>：顶部 File/Bills/Took 头部 + 每张票一个 tablewriter LABEL/VALUE 边框表格，按 spec sample 解析 result.pages[].bills[].items[]（过滤空值），断言失败回退 JSON；支持 -f|--file（必选）/ --profile / --output（table|json）/ --business-id / --verify-vat（默认 true，仅 Changed 时显式发送）/ --coord-restore-original / --pages / --crop-complete / --crop-value / --merge-elec / --return-ppi
 integration_ocr_test.go:  覆盖 runIntegrationOCR / renderOCRTable 的单元测试（table 渲染 spec sample / json 输出 / 非法扩展名 / 非法格式 / 文件不存在 / 无凭证 / 未知 profile / API 错误 / 异常结构回退），用 httptest 隔离网络

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -29,7 +29,7 @@ func newUpdateCmd() *cobra.Command {
 		Example: `  makecli update
   makecli update v0.2.0
   makecli update 0.2.0
-  makecli update v0.2.0 --force`,
+  makecli update --force v0.0.1`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,7 +1,9 @@
 /**
  * [INPUT]: 依赖 github.com/spf13/cobra、internal/update、internal/build
  * [OUTPUT]: 对外提供 newUpdateCmd 函数
- * [POS]: cmd 模块的 update 子命令，从 GitHub Releases 自更新二进制
+ * [POS]: cmd 模块的 update 子命令，从 GitHub Releases 自更新二进制；
+ *        无 arg 走 latest 流程，有 arg 走指定版本流程；降级需 --force；
+ *        DEV 版本跳过比较
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -16,19 +18,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// applyFunc 包装 update.Apply，便于测试打桩避免真实替换二进制。
+var applyFunc = update.Apply
+
 func newUpdateCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "update",
-		Short: "Update makecli to the latest version",
+	var force bool
+	cmd := &cobra.Command{
+		Use:          "update [version]",
+		Short:        "Update makecli to the latest or a specific version",
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(cmd)
+			target := ""
+			if len(args) == 1 {
+				target = args[0]
+			}
+			return runUpdate(cmd, target, force)
 		},
 	}
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "allow downgrade to an older version")
+	return cmd
 }
 
-func runUpdate(cmd *cobra.Command) error {
+func runUpdate(cmd *cobra.Command, target string, force bool) error {
 	currentVersion := build.Version
+	if target == "" {
+		return runUpdateLatest(cmd, currentVersion)
+	}
+	return runUpdateSpecific(cmd, currentVersion, target, force)
+}
 
+func runUpdateLatest(cmd *cobra.Command, currentVersion string) error {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Checking for updates...\n")
 
 	release, newer, err := update.CheckLatest(currentVersion)
@@ -44,13 +64,45 @@ func runUpdate(cmd *cobra.Command) error {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updating makecli: %s → %s\n",
 		formatCurrentVersion(currentVersion), release.TagName)
 
-	if err := update.Apply(release); err != nil {
+	if err := applyFunc(release); err != nil {
 		return err
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated makecli: %s → %s\n",
 		formatCurrentVersion(currentVersion), release.TagName)
+	return nil
+}
 
+func runUpdateSpecific(cmd *cobra.Command, currentVersion, target string, force bool) error {
+	tag, err := update.NormalizeTag(target)
+	if err != nil {
+		return err
+	}
+
+	release, err := update.GetRelease(tag)
+	if err != nil {
+		return err
+	}
+
+	cmp := update.CompareVersions(tag, currentVersion)
+	switch {
+	case cmp == 0:
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Already at %s, skipping.\n", tag)
+		return nil
+	case cmp < 0 && !force:
+		return fmt.Errorf("%s is older than current %s. Use --force to downgrade",
+			tag, formatCurrentVersion(currentVersion))
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updating makecli: %s → %s\n",
+		formatCurrentVersion(currentVersion), tag)
+
+	if err := applyFunc(release); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated makecli: %s → %s\n",
+		formatCurrentVersion(currentVersion), tag)
 	return nil
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -24,8 +24,12 @@ var applyFunc = update.Apply
 func newUpdateCmd() *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
-		Use:          "update [version]",
-		Short:        "Update makecli to the latest or a specific version",
+		Use:   "update [version]",
+		Short: "Update makecli to the latest or a specific version",
+		Example: `  makecli update
+  makecli update v0.2.0
+  makecli update 0.2.0
+  makecli update v0.2.0 --force`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -28,7 +28,6 @@ func newUpdateCmd() *cobra.Command {
 		Short: "Update makecli to the latest or a specific version",
 		Example: `  makecli update
   makecli update v0.2.0
-  makecli update 0.2.0
   makecli update --force v0.0.1`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,247 @@
+/**
+ * [INPUT]: 依赖 cmd 包内的 runUpdate / applyFunc（白盒），internal/update 的 Release 类型 + SetAPIBaseURLForTest，internal/build 的 Version
+ * [OUTPUT]: 覆盖 update 子命令决策逻辑的单元测试
+ * [POS]: cmd 模块 update.go 的配套测试，applyFunc 钩子打桩避免真实替换二进制
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qfeius/makecli/internal/build"
+	"github.com/qfeius/makecli/internal/update"
+	"github.com/spf13/cobra"
+)
+
+// setApplyFunc 在测试期间打桩 applyFunc 并在结束时恢复
+func setApplyFunc(t *testing.T, f func(*update.Release) error) *bool {
+	t.Helper()
+	called := false
+	old := applyFunc
+	applyFunc = func(r *update.Release) error {
+		called = true
+		return f(r)
+	}
+	t.Cleanup(func() { applyFunc = old })
+	return &called
+}
+
+// setBuildVersion 在测试期间覆盖 build.Version
+func setBuildVersion(t *testing.T, v string) {
+	t.Helper()
+	old := build.Version
+	build.Version = v
+	t.Cleanup(func() { build.Version = old })
+}
+
+// mockReleaseServer 启动 httptest 服务器并替换 apiBaseURL
+//
+//	status == 0 时不显式 WriteHeader（默认 200）
+//	body != nil 时返回 JSON 编码的 body
+func mockReleaseServer(t *testing.T, status int, body any) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if status != 0 {
+			w.WriteHeader(status)
+		}
+		if body != nil {
+			_ = json.NewEncoder(w).Encode(body)
+		}
+	}))
+	old := update.SetAPIBaseURLForTest(srv.URL)
+	return func() {
+		update.SetAPIBaseURLForTest(old)
+		srv.Close()
+	}
+}
+
+// noopApply 是 applyFunc 的成功桩
+func noopApply(_ *update.Release) error { return nil }
+
+// dummyCmd 提供一个有 OutOrStdout 的 cobra.Command 实例供 runUpdate 使用
+func dummyCmd() *cobra.Command {
+	return &cobra.Command{}
+}
+
+// ----------------------------------------------------------------------
+// 无 arg：latest 流程
+// ----------------------------------------------------------------------
+
+func TestRunUpdate_NoArg_AlreadyLatest(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *called {
+		t.Error("applyFunc should not be called when already up to date")
+	}
+}
+
+func TestRunUpdate_NoArg_Upgrade(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v2.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Error("applyFunc should be called when newer release is available")
+	}
+}
+
+// ----------------------------------------------------------------------
+// 指定版本
+// ----------------------------------------------------------------------
+
+func TestRunUpdate_SpecificVersion_Upgrade(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v2.0.0"})
+	defer cleanup()
+
+	var appliedTag string
+	called := setApplyFunc(t, func(r *update.Release) error {
+		appliedTag = r.TagName
+		return nil
+	})
+
+	if err := runUpdate(dummyCmd(), "v2.0.0", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Fatal("applyFunc should be called for upgrade")
+	}
+	if appliedTag != "v2.0.0" {
+		t.Errorf("applied tag = %q, want v2.0.0", appliedTag)
+	}
+}
+
+func TestRunUpdate_SpecificVersion_NormalizeWithoutV(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v2.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	// 输入不带 v 前缀
+	if err := runUpdate(dummyCmd(), "2.0.0", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Error("applyFunc should be called when target normalizes to a newer version")
+	}
+}
+
+func TestRunUpdate_SpecificVersion_SameVersion(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "v1.0.0", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *called {
+		t.Error("applyFunc should NOT be called when target == current")
+	}
+}
+
+func TestRunUpdate_SpecificVersion_DowngradeRefused(t *testing.T) {
+	setBuildVersion(t, "2.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	err := runUpdate(dummyCmd(), "v1.0.0", false)
+	if err == nil {
+		t.Fatal("expected downgrade refusal error")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should hint at --force, got: %v", err)
+	}
+	if *called {
+		t.Error("applyFunc should NOT be called on refused downgrade")
+	}
+}
+
+func TestRunUpdate_SpecificVersion_DowngradeWithForce(t *testing.T) {
+	setBuildVersion(t, "2.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "v1.0.0", true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Error("applyFunc should be called with --force on downgrade")
+	}
+}
+
+func TestRunUpdate_InvalidSemver(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	// mock server should not be hit
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	err := runUpdate(dummyCmd(), "abc", false)
+	if err == nil {
+		t.Fatal("expected error for invalid semver")
+	}
+	if *called {
+		t.Error("applyFunc should NOT be called for invalid input")
+	}
+}
+
+func TestRunUpdate_TagNotFound(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, http.StatusNotFound, nil)
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	err := runUpdate(dummyCmd(), "v9.9.9", false)
+	if err == nil {
+		t.Fatal("expected error for missing tag")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should say 'not found', got: %v", err)
+	}
+	if *called {
+		t.Error("applyFunc should NOT be called on tag not found")
+	}
+}
+
+func TestRunUpdate_DEVSkipsComparison(t *testing.T) {
+	setBuildVersion(t, "DEV")
+	// 选一个明显"旧"的版本作为 target —— DEV 应该允许而不需要 --force
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v0.0.1"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "v0.0.1", false); err != nil {
+		t.Fatalf("DEV should allow apply without --force, got: %v", err)
+	}
+	if !*called {
+		t.Error("applyFunc should be called when current is DEV")
+	}
+}

--- a/docs/superpowers/plans/2026-05-18-update-versioned.md
+++ b/docs/superpowers/plans/2026-05-18-update-versioned.md
@@ -1,0 +1,891 @@
+# makecli update [version] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `makecli update` to accept an optional `[version]` positional arg (e.g. `v0.2.0` or `0.2.0`), defaulting to latest. Downgrades require `--force`. DEV builds skip comparison.
+
+**Architecture:** Add 3 exported helpers to `internal/update` (`NormalizeTag` / `GetRelease` / `CompareVersions`). Refactor `cmd/update.go` into latest vs specific branches with an `applyFunc` test hook so unit tests don't actually replace the binary. New `cmd/update_test.go` covers all decision branches.
+
+**Tech Stack:** Go, `github.com/Masterminds/semver/v3` (already a dep), `github.com/spf13/cobra`, `net/http/httptest`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-18-update-versioned-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `internal/update/update.go` — add `NormalizeTag`, `GetRelease`, `CompareVersions`
+- `internal/update/update_test.go` — tests for the three new functions
+- `cmd/update.go` — `[version]` arg + `--force` flag, branches, `applyFunc` hook
+- `cmd/CLAUDE.md` — L2 update
+- `internal/update/CLAUDE.md` — L2 update
+
+**Create:**
+- `cmd/update_test.go` — first test file for the update command
+
+---
+
+## Task 1: Add `NormalizeTag` to `internal/update`
+
+**Files:**
+- Modify: `internal/update/update_test.go` (append test)
+- Modify: `internal/update/update.go` (add function + update OUTPUT header)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/update/update_test.go`:
+
+```go
+// -----------------------------------------------------------------------
+// NormalizeTag 测试
+// -----------------------------------------------------------------------
+
+func TestNormalizeTag(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"v0.2.0", "v0.2.0", false},
+		{"0.2.0", "v0.2.0", false},
+		{"v1.0.0-beta.1", "v1.0.0-beta.1", false},
+		{"1.0.0-beta.1", "v1.0.0-beta.1", false},
+		{"", "", true},
+		{"v", "", true},
+		{"abc", "", true},
+		{"1.2", "", true},
+		{"1.2.3.4", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := NormalizeTag(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NormalizeTag(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeTag(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `go test ./internal/update/ -run TestNormalizeTag -v`
+Expected: FAIL with "undefined: NormalizeTag"
+
+- [ ] **Step 3: Implement `NormalizeTag`**
+
+In `internal/update/update.go`, add under the `// 公开 API` section after `ListReleases`:
+
+```go
+// NormalizeTag 将输入归一化为带 v 前缀的合法 semver tag。
+//   "v0.2.0"          → "v0.2.0"
+//   "0.2.0"           → "v0.2.0"
+//   "1.0.0-beta.1"    → "v1.0.0-beta.1"
+//   非法 semver 返回 error。
+func NormalizeTag(input string) (string, error) {
+	stripped := strings.TrimPrefix(input, "v")
+	if stripped == "" {
+		return "", fmt.Errorf("invalid version %q: empty", input)
+	}
+	if _, err := semver.NewVersion(stripped); err != nil {
+		return "", fmt.Errorf("invalid version %q: %w", input, err)
+	}
+	return "v" + stripped, nil
+}
+```
+
+- [ ] **Step 4: Update L3 header**
+
+In `internal/update/update.go`, update the `[OUTPUT]` line to:
+
+```
+ * [OUTPUT]: 对外提供 CheckLatest / ListReleases / NormalizeTag / Apply 函数、Release / Asset 结构体
+```
+
+- [ ] **Step 5: Verify test passes**
+
+Run: `go test ./internal/update/ -run TestNormalizeTag -v`
+Expected: PASS, all 9 sub-tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/update/update.go internal/update/update_test.go
+git commit -m "feat(update): add NormalizeTag for version string handling"
+```
+
+---
+
+## Task 2: Add `GetRelease` to `internal/update`
+
+**Files:**
+- Modify: `internal/update/update_test.go`
+- Modify: `internal/update/update.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/update/update_test.go`:
+
+```go
+// -----------------------------------------------------------------------
+// GetRelease 测试
+// -----------------------------------------------------------------------
+
+func TestGetRelease_Success(t *testing.T) {
+	release := Release{
+		TagName: "v0.2.0",
+		Name:    "v0.2.0",
+		Assets:  []Asset{{Name: "makecli_0.2.0_linux_amd64.tar.gz"}},
+	}
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	got, err := GetRelease("v0.2.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TagName != "v0.2.0" {
+		t.Errorf("got tag %q, want v0.2.0", got.TagName)
+	}
+	if gotPath != "/repos/qfeius/makecli/releases/tags/v0.2.0" {
+		t.Errorf("unexpected path %q", gotPath)
+	}
+}
+
+func TestGetRelease_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	_, err := GetRelease("v9.9.9")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestGetRelease_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	_, err := GetRelease("v0.2.0")
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `go test ./internal/update/ -run TestGetRelease -v`
+Expected: FAIL with "undefined: GetRelease"
+
+- [ ] **Step 3: Implement `GetRelease`**
+
+In `internal/update/update.go`, add under the `// 公开 API` section after `NormalizeTag`:
+
+```go
+// GetRelease 按 tag 拉取指定 release。tag 必须是规范化形式（带 v 前缀）。
+//   404 → "release {tag} not found"
+//   其他非 200 → "failed to fetch release {tag}: HTTP {code}"
+func GetRelease(tag string) (*Release, error) {
+	url := fmt.Sprintf("%s/repos/qfeius/makecli/releases/tags/%s", apiBaseURL, tag)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch release %s: %w", tag, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release %s not found", tag)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch release %s: HTTP %d", tag, resp.StatusCode)
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to parse release %s: %w", tag, err)
+	}
+	return &release, nil
+}
+```
+
+- [ ] **Step 4: Update L3 header**
+
+Update `[OUTPUT]` line to:
+
+```
+ * [OUTPUT]: 对外提供 CheckLatest / ListReleases / NormalizeTag / GetRelease / Apply 函数、Release / Asset 结构体
+```
+
+- [ ] **Step 5: Verify test passes**
+
+Run: `go test ./internal/update/ -run TestGetRelease -v`
+Expected: PASS, all 3 sub-tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/update/update.go internal/update/update_test.go
+git commit -m "feat(update): add GetRelease for specific tag lookup"
+```
+
+---
+
+## Task 3: Add `CompareVersions` to `internal/update`
+
+**Files:**
+- Modify: `internal/update/update_test.go`
+- Modify: `internal/update/update.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/update/update_test.go`:
+
+```go
+// -----------------------------------------------------------------------
+// CompareVersions 测试
+// -----------------------------------------------------------------------
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		target, current string
+		want            int
+	}{
+		// 标准比较
+		{"v1.0.0", "v0.9.0", 1},
+		{"v1.0.0", "v1.0.0", 0},
+		{"v0.9.0", "v1.0.0", -1},
+		// 不带 v 前缀的 current 也支持
+		{"v1.0.0", "1.0.0", 0},
+		// DEV current → 返回 1（永远旧）
+		{"v1.0.0", "DEV", 1},
+		{"v0.0.1", "DEV", 1},
+		// 非法 current → 返回 1
+		{"v1.0.0", "abc", 1},
+		{"v1.0.0", "", 1},
+		{"v1.0.0", "v0.2.16-7-gd65ec7e", 1}, // git-describe dirty 形式
+		// pre-release
+		{"v1.0.0-beta.2", "v1.0.0-beta.1", 1},
+		{"v1.0.0", "v1.0.0-beta.1", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target+"_vs_"+tt.current, func(t *testing.T) {
+			got := CompareVersions(tt.target, tt.current)
+			if got != tt.want {
+				t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.target, tt.current, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `go test ./internal/update/ -run TestCompareVersions -v`
+Expected: FAIL with "undefined: CompareVersions"
+
+- [ ] **Step 3: Implement `CompareVersions`**
+
+In `internal/update/update.go`, add under the `// 公开 API` section after `GetRelease`:
+
+```go
+// CompareVersions 比较 target 与 current 的 semver 大小：
+//   target > current  →  1
+//   target == current →  0
+//   target < current  → -1
+//
+// 若 current 解析失败（DEV / dirty / 非法），返回 1 — 视为「current 永远旧」，
+// 这样调用方的「降级保护」对 DEV 构建自然失效。
+func CompareVersions(target, current string) int {
+	tgt, err := semver.NewVersion(strings.TrimPrefix(target, "v"))
+	if err != nil {
+		// target 应已被 NormalizeTag 校验过；保险返回 0
+		return 0
+	}
+	cur, err := semver.NewVersion(strings.TrimPrefix(current, "v"))
+	if err != nil {
+		return 1
+	}
+	return tgt.Compare(cur)
+}
+```
+
+- [ ] **Step 4: Update L3 header**
+
+Update `[OUTPUT]` line to:
+
+```
+ * [OUTPUT]: 对外提供 CheckLatest / ListReleases / NormalizeTag / GetRelease / CompareVersions / Apply 函数、Release / Asset 结构体
+```
+
+- [ ] **Step 5: Verify all tests pass**
+
+Run: `make test`
+Expected: PASS — all packages including the 11 new sub-tests across `TestCompareVersions`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/update/update.go internal/update/update_test.go
+git commit -m "feat(update): add CompareVersions with DEV-safe semantics"
+```
+
+---
+
+## Task 4: Refactor `cmd/update.go` with arg + flag + applyFunc hook
+
+**Files:**
+- Modify: `cmd/update.go`
+
+**Why standalone first:** This task introduces the new shape but keeps the latest-only behavior compiling and passing tests. Task 5 adds the test file that exercises both branches.
+
+- [ ] **Step 1: Replace `cmd/update.go` content**
+
+Replace the entire file with:
+
+```go
+/**
+ * [INPUT]: 依赖 github.com/spf13/cobra、internal/update、internal/build
+ * [OUTPUT]: 对外提供 newUpdateCmd 函数
+ * [POS]: cmd 模块的 update 子命令，从 GitHub Releases 自更新二进制；
+ *        无 arg 走 latest 流程，有 arg 走指定版本流程；降级需 --force；
+ *        DEV 版本跳过比较
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/qfeius/makecli/internal/build"
+	"github.com/qfeius/makecli/internal/update"
+	"github.com/spf13/cobra"
+)
+
+// applyFunc 包装 update.Apply，便于测试打桩避免真实替换二进制。
+var applyFunc = update.Apply
+
+func newUpdateCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:          "update [version]",
+		Short:        "Update makecli to the latest or a specific version",
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := ""
+			if len(args) == 1 {
+				target = args[0]
+			}
+			return runUpdate(cmd, target, force)
+		},
+	}
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "allow downgrade to an older version")
+	return cmd
+}
+
+func runUpdate(cmd *cobra.Command, target string, force bool) error {
+	currentVersion := build.Version
+	if target == "" {
+		return runUpdateLatest(cmd, currentVersion)
+	}
+	return runUpdateSpecific(cmd, currentVersion, target, force)
+}
+
+func runUpdateLatest(cmd *cobra.Command, currentVersion string) error {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Checking for updates...\n")
+
+	release, newer, err := update.CheckLatest(currentVersion)
+	if err != nil {
+		return err
+	}
+
+	if !newer {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Already up to date (%s)\n", release.TagName)
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updating makecli: %s → %s\n",
+		formatCurrentVersion(currentVersion), release.TagName)
+
+	if err := applyFunc(release); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated makecli: %s → %s\n",
+		formatCurrentVersion(currentVersion), release.TagName)
+	return nil
+}
+
+func runUpdateSpecific(cmd *cobra.Command, currentVersion, target string, force bool) error {
+	tag, err := update.NormalizeTag(target)
+	if err != nil {
+		return err
+	}
+
+	release, err := update.GetRelease(tag)
+	if err != nil {
+		return err
+	}
+
+	cmp := update.CompareVersions(tag, currentVersion)
+	switch {
+	case cmp == 0:
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Already at %s, skipping.\n", tag)
+		return nil
+	case cmp < 0 && !force:
+		return fmt.Errorf("%s is older than current %s. Use --force to downgrade",
+			tag, formatCurrentVersion(currentVersion))
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updating makecli: %s → %s\n",
+		formatCurrentVersion(currentVersion), tag)
+
+	if err := applyFunc(release); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated makecli: %s → %s\n",
+		formatCurrentVersion(currentVersion), tag)
+	return nil
+}
+
+// formatCurrentVersion 格式化当前版本号用于显示
+func formatCurrentVersion(v string) string {
+	v = strings.TrimPrefix(v, "v")
+	if v == "DEV" {
+		return v
+	}
+	return "v" + v
+}
+```
+
+- [ ] **Step 2: Verify build and existing behavior**
+
+Run: `make vet && make build`
+Expected: both succeed; no test changes yet so existing tests still pass via:
+```
+make test
+```
+
+- [ ] **Step 3: Smoke check help**
+
+Run: `./bin/makecli update --help 2>&1 | head -15`
+Expected: shows `update [version]` usage and `--force, -f` flag.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/update.go
+git commit -m "feat(update): accept [version] arg and --force flag
+
+Refactor into runUpdateLatest / runUpdateSpecific branches, with an
+applyFunc package var to enable test stubbing without replacing the
+real binary."
+```
+
+---
+
+## Task 5: Create `cmd/update_test.go` with TDD coverage
+
+**Files:**
+- Create: `cmd/update_test.go`
+
+- [ ] **Step 1: Create the test file**
+
+```go
+/**
+ * [INPUT]: 依赖 cmd 包内的 runUpdate / applyFunc（白盒），internal/update 的 Release 类型 + SetAPIBaseURLForTest，internal/build 的 Version
+ * [OUTPUT]: 覆盖 update 子命令决策逻辑的单元测试
+ * [POS]: cmd 模块 update.go 的配套测试，applyFunc 钩子打桩避免真实替换二进制
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qfeius/makecli/internal/build"
+	"github.com/qfeius/makecli/internal/update"
+	"github.com/spf13/cobra"
+)
+
+// setApplyFunc 在测试期间打桩 applyFunc 并在结束时恢复
+func setApplyFunc(t *testing.T, f func(*update.Release) error) *bool {
+	t.Helper()
+	called := false
+	old := applyFunc
+	applyFunc = func(r *update.Release) error {
+		called = true
+		return f(r)
+	}
+	t.Cleanup(func() { applyFunc = old })
+	return &called
+}
+
+// setBuildVersion 在测试期间覆盖 build.Version
+func setBuildVersion(t *testing.T, v string) {
+	t.Helper()
+	old := build.Version
+	build.Version = v
+	t.Cleanup(func() { build.Version = old })
+}
+
+// mockReleaseServer 启动 httptest 服务器并替换 apiBaseURL
+//   path == "" 时所有请求都返回 body；否则只匹配该 path 返回 body，其他返回 404
+func mockReleaseServer(t *testing.T, status int, body any) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if status != 0 {
+			w.WriteHeader(status)
+		}
+		if body != nil {
+			_ = json.NewEncoder(w).Encode(body)
+		}
+	}))
+	old := update.SetAPIBaseURLForTest(srv.URL)
+	return func() {
+		update.SetAPIBaseURLForTest(old)
+		srv.Close()
+	}
+}
+
+// noopApply 是 applyFunc 的成功桩
+func noopApply(_ *update.Release) error { return nil }
+
+// dummyCmd 提供一个有 OutOrStdout 的 cobra.Command 实例供 runUpdate 使用
+func dummyCmd() *cobra.Command {
+	return &cobra.Command{}
+}
+
+// ----------------------------------------------------------------------
+// 无 arg：latest 流程
+// ----------------------------------------------------------------------
+
+func TestRunUpdate_NoArg_AlreadyLatest(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *called {
+		t.Error("applyFunc should not be called when already up to date")
+	}
+}
+
+func TestRunUpdate_NoArg_Upgrade(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v2.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Error("applyFunc should be called when newer release is available")
+	}
+}
+
+// ----------------------------------------------------------------------
+// 指定版本
+// ----------------------------------------------------------------------
+
+func TestRunUpdate_SpecificVersion_Upgrade(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v2.0.0"})
+	defer cleanup()
+
+	var appliedTag string
+	called := setApplyFunc(t, func(r *update.Release) error {
+		appliedTag = r.TagName
+		return nil
+	})
+
+	if err := runUpdate(dummyCmd(), "v2.0.0", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Fatal("applyFunc should be called for upgrade")
+	}
+	if appliedTag != "v2.0.0" {
+		t.Errorf("applied tag = %q, want v2.0.0", appliedTag)
+	}
+}
+
+func TestRunUpdate_SpecificVersion_NormalizeWithoutV(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v2.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	// 输入不带 v 前缀
+	if err := runUpdate(dummyCmd(), "2.0.0", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Error("applyFunc should be called when target normalizes to a newer version")
+	}
+}
+
+func TestRunUpdate_SpecificVersion_SameVersion(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "v1.0.0", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *called {
+		t.Error("applyFunc should NOT be called when target == current")
+	}
+}
+
+func TestRunUpdate_SpecificVersion_DowngradeRefused(t *testing.T) {
+	setBuildVersion(t, "2.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	err := runUpdate(dummyCmd(), "v1.0.0", false)
+	if err == nil {
+		t.Fatal("expected downgrade refusal error")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should hint at --force, got: %v", err)
+	}
+	if *called {
+		t.Error("applyFunc should NOT be called on refused downgrade")
+	}
+}
+
+func TestRunUpdate_SpecificVersion_DowngradeWithForce(t *testing.T) {
+	setBuildVersion(t, "2.0.0")
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "v1.0.0", true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Error("applyFunc should be called with --force on downgrade")
+	}
+}
+
+func TestRunUpdate_InvalidSemver(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	// mock server should not be hit
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v1.0.0"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	err := runUpdate(dummyCmd(), "abc", false)
+	if err == nil {
+		t.Fatal("expected error for invalid semver")
+	}
+	if *called {
+		t.Error("applyFunc should NOT be called for invalid input")
+	}
+}
+
+func TestRunUpdate_TagNotFound(t *testing.T) {
+	setBuildVersion(t, "1.0.0")
+	cleanup := mockReleaseServer(t, http.StatusNotFound, nil)
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	err := runUpdate(dummyCmd(), "v9.9.9", false)
+	if err == nil {
+		t.Fatal("expected error for missing tag")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should say 'not found', got: %v", err)
+	}
+	if *called {
+		t.Error("applyFunc should NOT be called on tag not found")
+	}
+}
+
+func TestRunUpdate_DEVSkipsComparison(t *testing.T) {
+	setBuildVersion(t, "DEV")
+	// 选一个明显"旧"的版本作为 target —— DEV 应该允许而不需要 --force
+	cleanup := mockReleaseServer(t, 0, update.Release{TagName: "v0.0.1"})
+	defer cleanup()
+
+	called := setApplyFunc(t, noopApply)
+
+	if err := runUpdate(dummyCmd(), "v0.0.1", false); err != nil {
+		t.Fatalf("DEV should allow apply without --force, got: %v", err)
+	}
+	if !*called {
+		t.Error("applyFunc should be called when current is DEV")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify all pass**
+
+Run: `go test ./cmd/ -run TestRunUpdate -v`
+Expected: PASS — all 10 tests.
+
+- [ ] **Step 3: Run full suite**
+
+Run: `make test && make vet`
+Expected: both clean.
+
+- [ ] **Step 4: Run lint**
+
+Run: `make lint`
+Expected: 0 issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/update_test.go
+git commit -m "test(update): cover latest/specific/force/DEV decision branches"
+```
+
+---
+
+## Task 6: Update L2 docs
+
+**Files:**
+- Modify: `cmd/CLAUDE.md`
+- Modify: `internal/update/CLAUDE.md`
+
+- [ ] **Step 1: Update `cmd/CLAUDE.md`**
+
+In `cmd/CLAUDE.md`, locate the existing `update.go` line under `## 成员清单`:
+
+```
+update.go:           update 子命令，从 GitHub Releases 自更新二进制；直接 import internal/build 读取版本，委托 internal/update 执行检查和替换
+```
+
+Replace it with:
+
+```
+update.go:           update 子命令，支持 [version] 位置参数（v0.2.0 或 0.2.0）和 --force 标志；无 arg 走 CheckLatest 流程，指定版本走 GetRelease；CompareVersions 决定 upgrade/same/downgrade 分支，降级需 --force；DEV 版本跳过比较；applyFunc 包级变量便于测试打桩
+update_test.go:      覆盖 runUpdate 的单元测试（latest 已到位/有更新、specific 升级/同版本/降级拒绝/--force 降级/规范化无 v 前缀/非法 semver/tag 不存在/DEV 跳过比较），applyFunc 打桩避免真实替换二进制
+```
+
+- [ ] **Step 2: Update `internal/update/CLAUDE.md`**
+
+In `internal/update/CLAUDE.md`, replace the `update.go:` line with:
+
+```
+update.go:      自更新引擎，CheckLatest 查询 GitHub latest release、ListReleases 拉取最近 N 条 release、GetRelease 按 tag 精确查询、NormalizeTag 规范化版本号、CompareVersions 比较版本（DEV current 视为永远旧）、Apply 下载→解压→原子替换；内部实现 isNewer（semver 比较，DEV 视为始终可更新）、download/extractBinary/replaceBinary 完整流水线；导出 SetAPIBaseURLForTest 供 cmd 层测试替换 API URL
+```
+
+And replace the `update_test.go:` line with:
+
+```
+update_test.go: 覆盖 isNewer / assetName / findAsset / CheckLatest / ListReleases / NormalizeTag / GetRelease / CompareVersions 的单元测试，用 httptest 隔离网络
+```
+
+- [ ] **Step 3: Verify diffs**
+
+Run: `git diff cmd/CLAUDE.md internal/update/CLAUDE.md`
+Expected: only the two member-list lines changed in each file; `[PROTOCOL]` lines preserved.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/CLAUDE.md internal/update/CLAUDE.md
+git commit -m "docs: sync L2 maps for update [version] feature"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Full quality gates**
+
+Run in sequence (or as one chained command):
+
+```
+make test
+make vet
+make lint
+make build
+```
+
+All four must succeed (lint should report `0 issues.`).
+
+- [ ] **Step 2: Smoke test help**
+
+Run: `./bin/makecli update --help`
+Expected output includes:
+- `update [version]` in usage
+- `--force, -f` flag with description "allow downgrade to an older version"
+
+- [ ] **Step 3: Smoke test invalid input (no network needed)**
+
+Run: `./bin/makecli update abc 2>&1; echo "exit=$?"`
+Expected: prints error containing `invalid version`, `exit=1`.
+
+- [ ] **Step 4: Smoke test tag not found (network required)**
+
+Run: `./bin/makecli update v99.99.99 2>&1; echo "exit=$?"`
+Expected: prints error containing `not found`, `exit=1`.
+
+- [ ] **Step 5: Smoke test no-arg path (network required)**
+
+Run: `./bin/makecli update 2>&1 | head -5`
+Expected: prints "Checking for updates..." and either "Already up to date" or "Updating makecli: ..." (do NOT proceed past this — just verify the output line, then Ctrl+C if it stalls on download).
+
+Note: if the binary is freshly built from a non-tagged commit (`build.Version` is a git-describe form like `v0.2.16-9-gXXX`), the CompareVersions treats it as "always older" — so `update` will attempt the upgrade. Add a `--help` check elsewhere if you don't want the real download to happen during smoke.
+
+- [ ] **Step 6: No-op commit if verification reveals nothing**
+
+If issues surface, fix them as follow-up tasks. Otherwise, the previous commits already capture the work — nothing more to commit here.

--- a/docs/superpowers/specs/2026-05-18-update-versioned-design.md
+++ b/docs/superpowers/specs/2026-05-18-update-versioned-design.md
@@ -1,0 +1,267 @@
+# makecli update [version] 命令设计
+
+## 概述
+
+扩展 `makecli update` 接受可选位置参数 `[version]`，允许用户安装任意已发布的 release。默认行为（无 arg）保持不变 — 查 latest 并比较；显式指定版本时走新流程：规范化 → 拉 release → 与当前版本比较 → 按策略决定是否执行。降级（target 比 current 旧）默认拒绝，需 `--force` 覆盖。
+
+## 范围
+
+**包含：**
+- `internal/update`：新增 `NormalizeTag` / `GetRelease` / `CompareVersions` 三个导出函数
+- `cmd/update.go`：扩展为接受 `[version]` 位置参数 + `--force` 标志，分支处理 latest / specific 两条路径
+- `cmd/update_test.go`：新建（当前不存在），覆盖 CLI 层决策逻辑（不实际下载/替换二进制）
+- `internal/update/update_test.go`：增量测试新函数
+- 通过包级 `applyFunc` 钩子使 `cmd/update.go` 中的 `update.Apply` 调用可在测试中打桩
+- 文档：L2（`cmd/CLAUDE.md`、`internal/update/CLAUDE.md`）+ L3 文件头同步
+
+**不包含：**
+- `--check` 干跑模式（YAGNI）
+- 列出可升级版本（已有 `makecli version list`）
+- 自动选择最近 stable（policy 层未来需求，本期不做）
+- pre-release 标签过滤（用户显式指定 tag，由其负责）
+
+## 命令行为
+
+```
+makecli update                  # 默认行为：latest 流程，无更新则 no-op
+makecli update v0.2.20          # 指定版本，升级到 v0.2.20
+makecli update 0.2.20           # 等价（自动加 v 前缀）
+makecli update v0.2.20 -f       # --force 短形式（即使无降级也允许）
+makecli update v0.2.0           # 降级被拒绝，提示用 --force
+makecli update v0.2.0 --force   # 显式降级
+makecli update v0.2.16          # 同当前版本，no-op 退出
+makecli update abc              # 拒绝：not a valid version
+makecli update v9.9.9           # 拒绝：release not found on GitHub
+```
+
+### Flag
+
+| Flag | 简写 | 含义 |
+|------|------|------|
+| `--force` | `-f` | 允许降级到比当前版本旧的 release |
+
+### Cobra 配置
+
+```go
+Use:   "update [version]"
+Args:  cobra.MaximumNArgs(1)
+Short: "Update makecli to the latest or a specific version"
+SilenceUsage: true
+```
+
+## 行为矩阵
+
+| 输入 | 当前版本 | 行为 | 退出码 |
+|------|----------|------|--------|
+| `update`（无 arg） | latest | "Already up to date (vX)" | 0 |
+| `update`（无 arg） | < latest | "Updating makecli: vA → vB" → apply | 0 |
+| `update v0.2.20` | v0.2.16 | apply v0.2.20（升级） | 0 |
+| `update v0.2.16` | v0.2.16 | "Already at v0.2.16, skipping" | 0 |
+| `update v0.2.0` | v0.2.16 | refuse + 提示 | 1 |
+| `update v0.2.0 --force` | v0.2.16 | apply v0.2.0（降级） | 0 |
+| `update 0.2.20` | v0.2.16 | 规范化到 v0.2.20，按升级路径 | 0 |
+| `update abc` | 任意 | reject pre-flight | 1 |
+| `update v9.9.9`（tag 不存在） | 任意 | 404 → 明确错误 | 1 |
+| `update v0.2.0` | `DEV` / dirty | apply（跳过比较） | 0 |
+
+## 数据层设计（`internal/update`）
+
+### `NormalizeTag(input string) (string, error)`
+
+```go
+// "v0.2.0"  → "v0.2.0"
+// "0.2.0"   → "v0.2.0"
+// "v0.2.0-beta.1" → "v0.2.0-beta.1"
+// "abc"     → error
+// ""        → error
+func NormalizeTag(input string) (string, error)
+```
+
+实现：strip leading `v` → `semver.NewVersion(stripped)` 校验 → 返回 `"v" + stripped`。
+
+### `GetRelease(tag string) (*Release, error)`
+
+```go
+// 调用 GET {apiBaseURL}/repos/qfeius/makecli/releases/tags/{tag}
+// 200 → 返回 *Release
+// 404 → 明确错误 "release {tag} not found"
+// 其他 → "failed to fetch release {tag}: HTTP {code}"
+```
+
+`tag` 必须是 normalized 形式（带 `v` 前缀）。GitHub API 路径要求精确匹配 tag。
+
+### `CompareVersions(target, current string) int`
+
+```go
+// 语义：semver 比较 target vs current
+//   target > current → 1
+//   target == current → 0
+//   target < current → -1
+//
+// 特殊：current 为 DEV 或无效 semver 时返回 1（视为 current "永远旧"，跳过降级保护）
+// target 必须已是有效 semver（cmd 层已通过 NormalizeTag 保证）
+func CompareVersions(target, current string) int
+```
+
+不返回 error：DEV 已是预期场景，与其报错不如「降级保护对 DEV 关闭」更友好。
+
+### `Apply(release *Release)` — 保持不变
+
+已经接受任意 `*Release`，不绑定 latest。新流程直接复用。
+
+## CLI 层设计（`cmd/update.go`）
+
+### 包级 `applyFunc` 钩子
+
+```go
+// applyFunc 包装 update.Apply，测试中可打桩避免真实替换二进制
+var applyFunc = update.Apply
+```
+
+### `newUpdateCmd` 改造
+
+```go
+func newUpdateCmd() *cobra.Command {
+    var force bool
+    cmd := &cobra.Command{
+        Use:          "update [version]",
+        Short:        "Update makecli to the latest or a specific version",
+        Args:         cobra.MaximumNArgs(1),
+        SilenceUsage: true,
+        RunE: func(cmd *cobra.Command, args []string) error {
+            target := ""
+            if len(args) == 1 {
+                target = args[0]
+            }
+            return runUpdate(cmd, target, force)
+        },
+    }
+    cmd.Flags().BoolVarP(&force, "force", "f", false, "allow downgrade to an older version")
+    return cmd
+}
+```
+
+### `runUpdate` 分支
+
+```go
+func runUpdate(cmd *cobra.Command, target string, force bool) error {
+    currentVersion := build.Version
+
+    if target == "" {
+        return runUpdateLatest(cmd, currentVersion)
+    }
+    return runUpdateSpecific(cmd, currentVersion, target, force)
+}
+```
+
+`runUpdateLatest`：维持现有 `CheckLatest` 流程（仅是抽出来）。
+
+`runUpdateSpecific`：
+1. `tag, err := update.NormalizeTag(target)` — 非法直接返回错误
+2. `release, err := update.GetRelease(tag)` — 404 直接返回错误
+3. 若 `currentVersion` 非 DEV 且有效：`cmp := update.CompareVersions(tag, currentVersion)`
+   - `cmp == 0`：打印 "Already at {tag}, skipping" → return nil
+   - `cmp < 0 && !force`：return error "v0.2.0 is older than current v0.2.16. Use --force to downgrade."
+4. 打印 "Updating makecli: {current} → {tag}"
+5. `applyFunc(release)`
+6. 打印 "Updated makecli: {current} → {tag}"
+
+### "DEV 视为永远旧" 的实现位置
+
+在 `CompareVersions` 内部 — 当 `current` 解析失败（DEV / dirty / git-describe 输出），直接返回 `1`。这样 cmd 层逻辑统一：`cmp < 0` 才走降级分支，DEV 永远不会走到。
+
+## 错误信息（用户可见）
+
+| 场景 | 信息 |
+|------|------|
+| 非法 version 输入 | `invalid version "abc": ...semver error...` |
+| tag 不存在 | `release v9.9.9 not found` |
+| 平台 asset 缺失 | `no release available for darwin/arm64`（复用现有） |
+| 降级无 --force | `v0.2.0 is older than current v0.2.16. Use --force to downgrade.` |
+| 同版本 | `Already at v0.2.16, skipping.` |
+
+## 测试
+
+### `internal/update/update_test.go` 新增
+
+- `TestNormalizeTag`：表驱动覆盖 `v0.2.0` / `0.2.0` / `v0.2.0-beta.1` / `abc` / `""` / `"v"` / `"1.2"`（不完整）/ `"1.2.3.4"`（多段）
+- `TestGetRelease_Success`：httptest mock 返回 200 + Release
+- `TestGetRelease_NotFound`：404 → 错误包含 "not found"
+- `TestGetRelease_HTTPError`：500 → 错误包含状态码
+- `TestCompareVersions`：表驱动覆盖
+  - newer / equal / older
+  - current = `DEV` → 总返回 1
+  - current = `"abc"` / `""` → 总返回 1
+  - current = `"v0.2.16"` 带 v 前缀 → 与不带前缀等价
+  - target / current 含 pre-release（`-beta.1`）的对比
+
+### `cmd/update_test.go` 新建
+
+通过 `applyFunc` 注入打桩，避免真实替换二进制。结构：
+
+```go
+func setApplyFunc(t *testing.T, f func(*update.Release) error) {
+    t.Helper()
+    old := applyFunc
+    applyFunc = f
+    t.Cleanup(func() { applyFunc = old })
+}
+
+func setBuildVersion(t *testing.T, v string) {
+    t.Helper()
+    old := build.Version
+    build.Version = v
+    t.Cleanup(func() { build.Version = old })
+}
+```
+
+覆盖：
+
+- `TestRunUpdate_NoArg_AlreadyLatest`：mock GitHub latest 返回当前版本，断言 "Already up to date"，`applyFunc` 未被调用
+- `TestRunUpdate_NoArg_Upgrade`：mock latest 较新，断言 applyFunc 被调用且参数 tag 正确
+- `TestRunUpdate_SpecificVersion_Upgrade`：`update v0.2.20`，mock GetRelease，断言 applyFunc 被调用
+- `TestRunUpdate_SpecificVersion_NormalizeWithoutV`：`update 0.2.20` 等价于 `v0.2.20`
+- `TestRunUpdate_SpecificVersion_SameVersion`：target == current → "Already at" + applyFunc 未调用
+- `TestRunUpdate_SpecificVersion_DowngradeRefused`：返回 error，applyFunc 未调用
+- `TestRunUpdate_SpecificVersion_DowngradeWithForce`：`--force`，applyFunc 被调用
+- `TestRunUpdate_InvalidSemver`：`update abc` → error，无 HTTP 调用（mock server 不被命中即可验证）
+- `TestRunUpdate_TagNotFound`：mock 404，error 包含 "not found"
+- `TestRunUpdate_DEVSkipsComparison`：current = "DEV"，`update v0.2.0`（即使是更旧版本）无需 --force 也能 apply
+
+### 测试隔离
+
+复用 `update.SetAPIBaseURLForTest` 替换 GitHub API URL。`applyFunc` 在 `cmd` 包内打桩。
+
+## 文档同步
+
+### `cmd/CLAUDE.md`
+
+更新 `update.go` 行描述：
+```
+update.go:           update 子命令，支持 [version] 位置参数和 --force 标志；无 arg 走 CheckLatest 流程，指定版本走 GetRelease；CompareVersions 决定 upgrade/same/downgrade 分支，降级需 --force；DEV 版本跳过比较直接 apply
+update_test.go:      覆盖 runUpdate 的单元测试（latest/specific/upgrade/downgrade/force/同版本/非法 semver/tag 不存在/DEV），applyFunc 钩子打桩避免真实替换二进制
+```
+
+### `internal/update/CLAUDE.md`
+
+`update.go` 描述追加：
+```
+导出 NormalizeTag / GetRelease / CompareVersions 支持按 tag 查询和版本比较
+```
+
+### L3 文件头
+
+- `cmd/update.go` `[OUTPUT]` 不变（仍 `newUpdateCmd`），`[POS]` 描述更新
+- `cmd/update_test.go` 新文件，标准 L3 头
+- `internal/update/update.go` `[OUTPUT]` 增加 `NormalizeTag / GetRelease / CompareVersions`
+
+## 实现顺序（提示给后续 plan）
+
+1. `internal/update`: 实现 `NormalizeTag` + 测试
+2. `internal/update`: 实现 `GetRelease` + 测试
+3. `internal/update`: 实现 `CompareVersions` + 测试（含 DEV 分支）
+4. `cmd/update.go`: 引入 `applyFunc` 钩子；保持现有行为不变
+5. `cmd/update.go`: 拆出 `runUpdateLatest`；引入 `[version]` arg + `--force` flag；实现 `runUpdateSpecific`
+6. `cmd/update_test.go`: 新建，覆盖所有分支
+7. L2/L3 文档同步
+8. `make test && make vet && make lint && make build` 全绿；smoke：`./bin/makecli update --help` / `./bin/makecli update v9.9.9`（验证 404）

--- a/internal/update/CLAUDE.md
+++ b/internal/update/CLAUDE.md
@@ -2,7 +2,7 @@
 > L2 | 父级: /CLAUDE.md
 
 ## 成员清单
-update.go:      自更新引擎，CheckLatest 查询 GitHub latest release、ListReleases 拉取最近 N 条 release、Apply 下载→解压→原子替换；内部实现 isNewer（semver 比较，DEV 视为始终可更新）、download/extractBinary/replaceBinary 完整流水线；导出 SetAPIBaseURLForTest 供 cmd 层测试替换 API URL
-update_test.go: 覆盖 isNewer / assetName / findAsset / CheckLatest / ListReleases 的单元测试，用 httptest 隔离网络
+update.go:      自更新引擎，CheckLatest 查询 GitHub latest release、ListReleases 拉取最近 N 条 release、GetRelease 按 tag 精确查询、NormalizeTag 规范化版本号、CompareVersions 比较版本（DEV current 视为永远旧）、Apply 下载→解压→原子替换；内部 fetchJSON 抽出 GET/解码/状态码共享；内部实现 isNewer（semver 比较，DEV 视为始终可更新）、download/extractBinary/replaceBinary 完整流水线；导出 SetAPIBaseURLForTest 供 cmd 层测试替换 API URL
+update_test.go: 覆盖 isNewer / assetName / findAsset / CheckLatest / ListReleases / NormalizeTag / GetRelease / CompareVersions 的单元测试，用 httptest 隔离网络
 
 [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -56,42 +56,29 @@ var apiBaseURL = "https://api.github.com"
 func CheckLatest(currentVersion string) (*Release, bool, error) {
 	url := apiBaseURL + "/repos/qfeius/makecli/releases/latest"
 
-	resp, err := http.Get(url)
+	var release Release
+	status, err := fetchJSON(url, &release)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to check for updates: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, false, fmt.Errorf("failed to check for updates: HTTP %d", resp.StatusCode)
+	if status != http.StatusOK {
+		return nil, false, fmt.Errorf("failed to check for updates: HTTP %d", status)
 	}
 
-	var release Release
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, false, fmt.Errorf("failed to parse release info: %w", err)
-	}
-
-	newer := isNewer(currentVersion, release.TagName)
-	return &release, newer, nil
+	return &release, isNewer(currentVersion, release.TagName), nil
 }
 
 // ListReleases 拉取最近 limit 条 release（按 created_at 倒序）
 func ListReleases(limit int) ([]Release, error) {
 	url := fmt.Sprintf("%s/repos/qfeius/makecli/releases?per_page=%d", apiBaseURL, limit)
 
-	resp, err := http.Get(url)
+	var releases []Release
+	status, err := fetchJSON(url, &releases)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list releases: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to list releases: HTTP %d", resp.StatusCode)
-	}
-
-	var releases []Release
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
-		return nil, fmt.Errorf("failed to parse releases: %w", err)
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("failed to list releases: HTTP %d", status)
 	}
 
 	return releases, nil
@@ -120,24 +107,39 @@ func NormalizeTag(input string) (string, error) {
 func GetRelease(tag string) (*Release, error) {
 	url := fmt.Sprintf("%s/repos/qfeius/makecli/releases/tags/%s", apiBaseURL, tag)
 
-	resp, err := http.Get(url)
+	var release Release
+	status, err := fetchJSON(url, &release)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch release %s: %w", tag, err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusNotFound {
+	if status == http.StatusNotFound {
 		return nil, fmt.Errorf("release %s not found", tag)
 	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch release %s: HTTP %d", tag, resp.StatusCode)
-	}
-
-	var release Release
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, fmt.Errorf("failed to parse release %s: %w", tag, err)
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch release %s: HTTP %d", tag, status)
 	}
 	return &release, nil
+}
+
+// fetchJSON 发送 GET 请求并将响应体解码到 target。
+// 返回 HTTP 状态码（供调用方做语义化错误映射，如 404→"not found"）。
+// 网络错误返回 (0, err)；非 200 状态返回 (code, nil)，body 不解码；
+// 200 但 JSON 解析失败返回 (200, err)。
+func fetchJSON(url string, target any) (int, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, nil
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return resp.StatusCode, err
+	}
+	return resp.StatusCode, nil
 }
 
 // Apply 下载指定 release 的 asset 并替换当前二进制

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 net/http、archive/tar、compress/gzip、encoding/json、github.com/Masterminds/semver/v3
- * [OUTPUT]: 对外提供 CheckLatest / ListReleases / NormalizeTag / Apply 函数、Release / Asset 结构体
+ * [OUTPUT]: 对外提供 CheckLatest / ListReleases / NormalizeTag / GetRelease / Apply 函数、Release / Asset 结构体
  * [POS]: internal/update 的核心引擎，被 cmd/update.go 消费
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -112,6 +112,32 @@ func NormalizeTag(input string) (string, error) {
 		return "", fmt.Errorf("invalid version %q: %w", input, err)
 	}
 	return "v" + stripped, nil
+}
+
+// GetRelease 按 tag 拉取指定 release。tag 必须是规范化形式（带 v 前缀）。
+//   404 → "release {tag} not found"
+//   其他非 200 → "failed to fetch release {tag}: HTTP {code}"
+func GetRelease(tag string) (*Release, error) {
+	url := fmt.Sprintf("%s/repos/qfeius/makecli/releases/tags/%s", apiBaseURL, tag)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch release %s: %w", tag, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release %s not found", tag)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch release %s: HTTP %d", tag, resp.StatusCode)
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to parse release %s: %w", tag, err)
+	}
+	return &release, nil
 }
 
 // Apply 下载指定 release 的 asset 并替换当前二进制

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 net/http、archive/tar、compress/gzip、encoding/json、github.com/Masterminds/semver/v3
- * [OUTPUT]: 对外提供 CheckLatest / ListReleases / Apply 函数、Release / Asset 结构体
+ * [OUTPUT]: 对外提供 CheckLatest / ListReleases / NormalizeTag / Apply 函数、Release / Asset 结构体
  * [POS]: internal/update 的核心引擎，被 cmd/update.go 消费
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -95,6 +95,23 @@ func ListReleases(limit int) ([]Release, error) {
 	}
 
 	return releases, nil
+}
+
+// NormalizeTag 将输入归一化为带 v 前缀的合法 semver tag。
+//
+//	"v0.2.0"          → "v0.2.0"
+//	"0.2.0"           → "v0.2.0"
+//	"1.0.0-beta.1"    → "v1.0.0-beta.1"
+//	非法 semver 返回 error。
+func NormalizeTag(input string) (string, error) {
+	stripped := strings.TrimPrefix(input, "v")
+	if stripped == "" {
+		return "", fmt.Errorf("invalid version %q: empty", input)
+	}
+	if _, err := semver.StrictNewVersion(stripped); err != nil {
+		return "", fmt.Errorf("invalid version %q: %w", input, err)
+	}
+	return "v" + stripped, nil
 }
 
 // Apply 下载指定 release 的 asset 并替换当前二进制

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 net/http、archive/tar、compress/gzip、encoding/json、github.com/Masterminds/semver/v3
- * [OUTPUT]: 对外提供 CheckLatest / ListReleases / NormalizeTag / GetRelease / Apply 函数、Release / Asset 结构体
+ * [OUTPUT]: 对外提供 CheckLatest / ListReleases / NormalizeTag / GetRelease / CompareVersions / Apply 函数、Release / Asset 结构体
  * [POS]: internal/update 的核心引擎，被 cmd/update.go 消费
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -119,6 +119,27 @@ func GetRelease(tag string) (*Release, error) {
 		return nil, fmt.Errorf("failed to fetch release %s: HTTP %d", tag, status)
 	}
 	return &release, nil
+}
+
+// CompareVersions 比较 target 与 current 的 semver 大小：
+//
+//	target > current  →  1
+//	target == current →  0
+//	target < current  → -1
+//
+// 若 current 解析失败（DEV / dirty / 非法），返回 1 — 视为「current 永远旧」，
+// 这样调用方的「降级保护」对 DEV 构建自然失效。
+func CompareVersions(target, current string) int {
+	tgt, err := semver.NewVersion(strings.TrimPrefix(target, "v"))
+	if err != nil {
+		// target 应已被 NormalizeTag 校验过；保险返回 0
+		return 0
+	}
+	cur, err := semver.NewVersion(strings.TrimPrefix(current, "v"))
+	if err != nil {
+		return 1
+	}
+	return tgt.Compare(cur)
 }
 
 // fetchJSON 发送 GET 请求并将响应体解码到 target。

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -257,5 +258,74 @@ func TestNormalizeTag(t *testing.T) {
 				t.Errorf("NormalizeTag(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// -----------------------------------------------------------------------
+// GetRelease 测试
+// -----------------------------------------------------------------------
+
+func TestGetRelease_Success(t *testing.T) {
+	release := Release{
+		TagName: "v0.2.0",
+		Name:    "v0.2.0",
+		Assets:  []Asset{{Name: "makecli_0.2.0_linux_amd64.tar.gz"}},
+	}
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	got, err := GetRelease("v0.2.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TagName != "v0.2.0" {
+		t.Errorf("got tag %q, want v0.2.0", got.TagName)
+	}
+	if gotPath != "/repos/qfeius/makecli/releases/tags/v0.2.0" {
+		t.Errorf("unexpected path %q", gotPath)
+	}
+}
+
+func TestGetRelease_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	_, err := GetRelease("v9.9.9")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestGetRelease_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	oldURL := apiBaseURL
+	apiBaseURL = server.URL
+	defer func() { apiBaseURL = oldURL }()
+
+	_, err := GetRelease("v0.2.0")
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
 	}
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -225,3 +225,37 @@ func TestListReleases_ParseError(t *testing.T) {
 		t.Fatal("expected parse error")
 	}
 }
+
+// -----------------------------------------------------------------------
+// NormalizeTag 测试
+// -----------------------------------------------------------------------
+
+func TestNormalizeTag(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"v0.2.0", "v0.2.0", false},
+		{"0.2.0", "v0.2.0", false},
+		{"v1.0.0-beta.1", "v1.0.0-beta.1", false},
+		{"1.0.0-beta.1", "v1.0.0-beta.1", false},
+		{"", "", true},
+		{"v", "", true},
+		{"abc", "", true},
+		{"1.2", "", true},
+		{"1.2.3.4", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := NormalizeTag(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NormalizeTag(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeTag(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -329,3 +329,40 @@ func TestGetRelease_HTTPError(t *testing.T) {
 		t.Fatal("expected error for HTTP 500")
 	}
 }
+
+// -----------------------------------------------------------------------
+// CompareVersions 测试
+// -----------------------------------------------------------------------
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		target, current string
+		want            int
+	}{
+		// 标准比较
+		{"v1.0.0", "v0.9.0", 1},
+		{"v1.0.0", "v1.0.0", 0},
+		{"v0.9.0", "v1.0.0", -1},
+		// 不带 v 前缀的 current 也支持
+		{"v1.0.0", "1.0.0", 0},
+		// DEV current → 返回 1（永远旧）
+		{"v1.0.0", "DEV", 1},
+		{"v0.0.1", "DEV", 1},
+		// 非法 current → 返回 1
+		{"v1.0.0", "abc", 1},
+		{"v1.0.0", "", 1},
+		{"v1.0.0", "v0.2.16-7-gd65ec7e", 1}, // git-describe dirty 形式
+		// pre-release
+		{"v1.0.0-beta.2", "v1.0.0-beta.1", 1},
+		{"v1.0.0", "v1.0.0-beta.1", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target+"_vs_"+tt.current, func(t *testing.T) {
+			got := CompareVersions(tt.target, tt.current)
+			if got != tt.want {
+				t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.target, tt.current, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `makecli update` 接受可选位置参数 `[version]`（如 `v0.2.0` 或 `0.2.0`，自动加 `v` 前缀），无 arg 时保持原有 latest 流程
- 降级（target 比 current 旧）默认拒绝，需 `--force` / `-f` 覆盖；同版本 no-op；DEV 构建跳过比较直接 apply
- `internal/update` 新增 `NormalizeTag` / `GetRelease` / `CompareVersions` 三个导出函数，并抽出 `fetchJSON` helper 让 `CheckLatest` / `ListReleases` / `GetRelease` 共享 GET+解码+错误包装的实现

## Test Plan

- [x] `make test` 全 pass（cmd 新增 10 个 `TestRunUpdate_*` 测试，update 新增 17 个 sub-test 覆盖 NormalizeTag/GetRelease/CompareVersions）
- [x] `make vet` clean
- [x] `make lint` 0 issues
- [x] `make build` 产出二进制
- [x] 手动 smoke：`update --help`（显示 `[version]` + `--force/-f`）、`update abc`（exit 1, `invalid version`）、`update v99.99.99`（exit 1, `release ... not found`）

## Reference

- Spec: `docs/superpowers/specs/2026-05-18-update-versioned-design.md`
- Plan: `docs/superpowers/plans/2026-05-18-update-versioned.md`