### PR TITLE
ci: skip Claude review/security jobs on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
       - run: go test ./...
 
   security:
-    if: github.event_name == 'pull_request'
+    # Skip on fork PRs: GitHub forces a read-only token and withholds secrets +
+    # id-token for cross-repo PRs, so the OIDC fetch can never succeed. Fork PRs
+    # get reviewed by a maintainer commenting @claude (see claude.yml).
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip on fork PRs: GitHub forces a read-only token and withholds secrets +
+    # id-token for cross-repo PRs, so the OIDC fetch can never succeed. Fork PRs
+    # get reviewed by a maintainer commenting @claude (see claude.yml).
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 问题

PR #12（来自 fork `xunzou/makecli`）的 `claude-review` job 失败：

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## 根因

工作流权限没问题——`claude-code-review.yml`、`ci.yml`、`claude.yml` 都已声明 `id-token: write`，连 PR #12 的 commit 里也有。

真正原因是 GitHub 对 **fork PR** 的安全模型：对来自 fork 的 `pull_request`，GitHub 强制把 `GITHUB_TOKEN` 降为只读、**忽略**一切写权限请求（含 `id-token: write`），并**不下发 secrets**。于是 `anthropics/claude-code-action` 申请 OIDC token 必然失败。再加任何 `id-token: write` 都无济于事；即便 OIDC 通过，`secrets.CLAUDE_CODE_OAUTH_TOKEN` 对 fork PR 也是空的。

## 改动

给 `security`（ci.yml）和 `claude-review`（claude-code-review.yml）两个 job 加 guard，只在**同仓库 PR** 上运行：

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

fork PR 不再产生红叉噪音；外部 PR 的审查改由维护者评论 `@claude` 触发——`claude.yml` 走 `issue_comment` 事件，始终在 base repo 上下文运行，权限与 secret 齐全。

## 验证

- 两个 YAML 文件本地 `YAML.load_file` 解析通过。