### PR TITLE
fix(config): platform-aware atomic file replacement with fail-safe Windows overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - **config**: Profile names are validated against a conservative grammar (`^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`) and every persisted INI value rejects embedded newlines and leading/trailing whitespace, closing an INI section-injection window (e.g. a profile named `evil]\n[other` or a token value smuggling a `[section]` line)
+- **config**: Atomic file replacement is platform-aware — on Windows the single-step overwrite rename (`MoveFileEx` + `REPLACE_EXISTING`) is retried with backoff when the destination is held open by another process, never touching the existing destination on failure; POSIX keeps plain atomic rename semantics
 
 ## [v0.5.5] - 2026-07-14
 

--- a/internal/config/CLAUDE.md
+++ b/internal/config/CLAUDE.md
@@ -2,8 +2,11 @@
 > L2 | 父级: /CLAUDE.md
 
 ## 成员清单
-- `atomic.go`: 落盘原语 atomicWrite（同目录 temp + rename 原子替换，render 出错清理不留残留），被 Save/SaveConfig 复用，消除 O_TRUNC 直写的崩溃损坏窗口
-- `atomic_test.go`: 覆盖 atomicWrite 落盘内容/权限0600/无临时残留/覆盖既有文件/render 出错传播不落盘
+- `atomic.go`: 落盘原语 atomicWrite（同目录 temp + ReplaceFile 原子替换，render 出错清理不留残留），被 Save/SaveConfig 复用，消除 O_TRUNC 直写的崩溃损坏窗口；替换动作收口到 build-tag 分发的 ReplaceFile（POSIX 直通 rename，Windows 单步覆盖原语退避重试，两分支合同一致：失败时目标原样保有旧内容）
+- `atomic_replace.go`: ReplaceFile 平台分支（!windows）——POSIX rename(2) 对既有目标本就原子覆盖，直接透传 os.Rename；导出供 internal/notifier 缓存落盘复用
+- `atomic_replace_windows.go`: ReplaceFile 平台分支（windows）——失败安全替换：只用单步覆盖原语（renameFile=os.Rename，MoveFileEx+REPLACE_EXISTING；包级变量供失败注入测试）退避重试 3 次 ×10ms，任何失败路径都不触碰既有目标——dst 要么已是新内容、要么原样保有旧内容，无路径缺失窗口；目标被独占时如实报错让调用方重试，不冒丢数据险；零额外依赖（刻意不引入 golang.org/x/sys）
+- `atomic_replace_windows_test.go`: Windows 分支的失败合同测试（windows-tagged）——renameFile 注入失败证明重复失败后 dst 原样保有旧内容且每次尝试时在位、重试计数正确、前失败后成功的重试出口
+- `atomic_test.go`: 覆盖 atomicWrite 落盘内容/权限0600/无临时残留/覆盖既有文件/render 出错传播不落盘 + ReplaceFile 非 Windows 分支覆盖既有目标（内容替换/源消失/权限保留）
 - `paths.go`: 配置目录解析中枢，提供 Dir 函数与 EnvConfigDir 常量，$MAKE_CLI_CONFIG_DIR 非空时覆盖默认 ~/.make
 - `paths_test.go`: 覆盖 Dir 默认回退与 $MAKE_CLI_CONFIG_DIR 覆盖语义，串联 Save/Load 的 env 隔离测试
 - `credentials.go`: 读写 credentials 文件（默认 ~/.make/credentials，INI 格式），提供 Load/Save/CredentialsPath，Credentials/Profile 类型；Save 经 atomicWrite 原子落盘，落盘前过 INI 注入防线（ValidateProfileName 文法+保留名、validateINIValue 拒 token 含换行/首尾空白）

--- a/internal/config/atomic.go
+++ b/internal/config/atomic.go
@@ -1,7 +1,8 @@
 /**
- * [INPUT]: 依赖 io、os、path/filepath
- * [OUTPUT]: 对外提供（包内）atomicWrite——同目录临时文件 + rename 原子替换
- * [POS]: internal/config 的落盘原语，被 credentials.Save / config.SaveConfig 复用，消除 O_TRUNC 写入中途崩溃的损坏窗口
+ * [INPUT]: 依赖 io、os、path/filepath；依赖 atomic_replace.go / atomic_replace_windows.go 的 ReplaceFile（平台分支）
+ * [OUTPUT]: 对外提供（包内）atomicWrite——同目录临时文件 + ReplaceFile 原子替换
+ * [POS]: internal/config 的落盘原语，被 credentials.Save / config.SaveConfig 复用，消除 O_TRUNC 写入中途崩溃的损坏窗口；
+ *        覆盖既有目标的 rename 语义因平台而异（Windows 目标被占用时会失败），故替换动作收口到 build-tag 分发的 ReplaceFile
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -14,7 +15,8 @@ import (
 )
 
 // atomicWrite 把 render 产出的内容原子写入 path：先写同目录临时文件（保证同一文件系统
-// 上的 rename 是原子的），成功后 rename 覆盖目标。render 出错或写入失败则清理临时文件、
+// 上的替换是原子的），成功后经 ReplaceFile 覆盖目标（POSIX 直接 rename，Windows 用
+// 单步覆盖原语退避重试，见 atomic_replace*.go）。render 出错或写入失败则清理临时文件、
 // 不触碰目标——杜绝 O_TRUNC 直写在崩溃/并发时留下半截损坏文件的窗口。
 func atomicWrite(path string, perm os.FileMode, render func(w io.Writer) error) error {
 	dir := filepath.Dir(path)
@@ -23,7 +25,7 @@ func atomicWrite(path string, perm os.FileMode, render func(w io.Writer) error) 
 		return err
 	}
 	tmpName := tmp.Name()
-	// 失败路径统一清理；成功 rename 后 tmpName 已不存在，Remove 无害。
+	// 失败路径统一清理；成功替换后 tmpName 已不存在，Remove 无害。
 	defer func() { _ = os.Remove(tmpName) }()
 
 	if err := render(tmp); err != nil {
@@ -36,5 +38,5 @@ func atomicWrite(path string, perm os.FileMode, render func(w io.Writer) error) 
 	if err := os.Chmod(tmpName, perm); err != nil {
 		return err
 	}
-	return os.Rename(tmpName, path)
+	return ReplaceFile(tmpName, path)
 }

--- a/internal/config/atomic_replace.go
+++ b/internal/config/atomic_replace.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+/**
+ * [INPUT]: 依赖 os
+ * [OUTPUT]: 对外提供 ReplaceFile——非 Windows 平台的原子文件替换（导出：internal/notifier 的缓存落盘复用）
+ * [POS]: internal/config 落盘原语的平台分支（POSIX）：rename(2) 对既有目标本就是原子覆盖，直接透传 os.Rename；
+ *        Windows 侧的单步覆盖重试兄弟实现见 atomic_replace_windows.go，两者共同支撑 atomic.go 的 atomicWrite 与 internal/notifier 的缓存写入
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package config
+
+import "os"
+
+// ReplaceFile 用 src 原子替换 dst。POSIX rename(2) 对既有目标是原子覆盖，无需额外处理。
+func ReplaceFile(src, dst string) error {
+	return os.Rename(src, dst)
+}

--- a/internal/config/atomic_replace_windows.go
+++ b/internal/config/atomic_replace_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+/**
+ * [INPUT]: 依赖 os、time
+ * [OUTPUT]: 对外提供 ReplaceFile——Windows 平台的失败安全文件替换（单步覆盖重试，绝不挪动/删除既有目标；导出：internal/notifier 的缓存落盘复用）
+ * [POS]: internal/config 落盘原语的平台分支（Windows）：os.Rename 在 Windows 上即 MoveFileEx(MOVEFILE_REPLACE_EXISTING)
+ *        单步覆盖原语——成功即原子替换，失败（目标被无 FILE_SHARE_DELETE 的进程占用）则退避重试，任何失败路径
+ *        都不触碰既有目标：dst 要么已是新内容、要么原样保有旧内容，不存在路径缺失窗口或旧文件丢失
+ *        （曾先删目标再改名，二次改名失败即丢最后完好的配置/缓存）；
+ *        POSIX 侧的直通实现见 atomic_replace.go，两者共同支撑 atomic.go 的 atomicWrite 与 internal/notifier 的缓存写入
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package config
+
+import (
+	"os"
+	"time"
+)
+
+// Windows 替换重试参数：并发读取方（如另一个 makecli 进程正在 Load）通常在毫秒级释放句柄，
+// 少量短退避即可覆盖；仍失败则把最后一次错误如实上抛，不无限等待。
+const (
+	replaceRetryCount = 3
+	replaceRetryDelay = 10 * time.Millisecond
+)
+
+// renameFile 是唯一的替换原语出口，包级变量供失败注入测试打桩——验证「替换失败时
+// dst 原样保有旧内容」的合同不依赖真实文件锁场景。
+var renameFile = os.Rename
+
+// ReplaceFile 用 src 替换 dst，失败安全：只用 os.Rename 这一个单步覆盖原语
+// （Windows 上是 MoveFileEx + MOVEFILE_REPLACE_EXISTING），失败则退避重试。
+// 刻意不做「挪走/删除旧目标再放新文件」的回退——那会制造 dst 路径缺失窗口，
+// 且第二步失败时旧内容不在原位。这里的合同是：本函数返回错误时，dst 原样保有
+// 替换前的内容；代价是目标被独占进程长期打开时替换报错（调用方重试即可），
+// 而不是冒丢数据的险去强行成功。
+func ReplaceFile(src, dst string) error {
+	var err error
+	for attempt := 0; attempt < replaceRetryCount; attempt++ {
+		if attempt > 0 {
+			time.Sleep(replaceRetryDelay)
+		}
+		if err = renameFile(src, dst); err == nil {
+			return nil
+		}
+	}
+	return err
+}

--- a/internal/config/atomic_replace_windows_test.go
+++ b/internal/config/atomic_replace_windows_test.go
@@ -1,0 +1,88 @@
+//go:build windows
+
+/**
+ * [INPUT]: 依赖包内 ReplaceFile/renameFile（白盒打桩）、errors、os、path/filepath、testing
+ * [OUTPUT]: 覆盖 Windows 替换的失败合同——重复失败后 dst 原样保有旧内容、路径全程存在、重试计数正确
+ * [POS]: internal/config 的 Windows 平台分支测试，用 renameFile 注入失败模拟目标被独占，不依赖真实文件锁
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReplaceFileFailureKeepsDestination 锁定失败合同：替换失败的每一步 dst 都原样
+// 保有旧内容——绝无「旧文件已失、新文件未至」的中间态（曾用删除后重试实现丢过数据）。
+func TestReplaceFileFailureKeepsDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.tmp")
+	dst := filepath.Join(dir, "dst.conf")
+	if err := os.WriteFile(src, []byte("new"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	injected := errors.New("sharing violation (injected)")
+	calls := 0
+	orig := renameFile
+	renameFile = func(from, to string) error {
+		calls++
+		// 每次尝试时 dst 都必须原样在位——失败注入点即合同检查点
+		if b, err := os.ReadFile(dst); err != nil || string(b) != "old" {
+			t.Errorf("attempt %d: dst content = %q err=%v, want old content intact", calls, b, err)
+		}
+		return injected
+	}
+	t.Cleanup(func() { renameFile = orig })
+
+	if err := ReplaceFile(src, dst); !errors.Is(err, injected) {
+		t.Fatalf("ReplaceFile = %v, want injected error", err)
+	}
+	if calls != replaceRetryCount {
+		t.Errorf("rename attempts = %d, want %d", calls, replaceRetryCount)
+	}
+	if b, _ := os.ReadFile(dst); string(b) != "old" {
+		t.Errorf("dst after failure = %q, want old content intact", b)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Errorf("src should remain for caller cleanup, stat err: %v", err)
+	}
+}
+
+// TestReplaceFileRetrySucceeds 前两次失败、第三次成功——重试路径的成功出口。
+func TestReplaceFileRetrySucceeds(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.tmp")
+	dst := filepath.Join(dir, "dst.conf")
+	if err := os.WriteFile(src, []byte("new"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	orig := renameFile
+	renameFile = func(from, to string) error {
+		calls++
+		if calls < 3 {
+			return errors.New("busy (injected)")
+		}
+		return os.Rename(from, to)
+	}
+	t.Cleanup(func() { renameFile = orig })
+
+	if err := ReplaceFile(src, dst); err != nil {
+		t.Fatalf("ReplaceFile: %v", err)
+	}
+	if b, _ := os.ReadFile(dst); string(b) != "new" {
+		t.Errorf("dst after success = %q, want new content", b)
+	}
+}

--- a/internal/config/atomic_test.go
+++ b/internal/config/atomic_test.go
@@ -1,7 +1,7 @@
 /**
- * [INPUT]: 依赖 io、os、path/filepath、strings、testing；包内 atomicWrite（白盒）
+ * [INPUT]: 依赖 io、os、path/filepath、strings、testing；包内 atomicWrite / ReplaceFile（白盒）
  * [OUTPUT]: 单元测试，无导出
- * [POS]: internal/config 原子写 helper 的测试，覆盖落盘内容、权限、无临时文件残留、覆盖既有文件
+ * [POS]: internal/config 原子写 helper 的测试，覆盖落盘内容、权限、无临时文件残留、覆盖既有文件、ReplaceFile 平台分支（非 Windows 路径）
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -70,6 +70,42 @@ func TestAtomicWriteOverwrites(t *testing.T) {
 	got, _ := os.ReadFile(path)
 	if string(got) != "NEW\n" {
 		t.Errorf("content = %q, want fully replaced %q", got, "NEW\n")
+	}
+}
+
+// TestReplaceFileOverwritesExisting 验证 ReplaceFile（当前平台分支）覆盖既有目标：
+// 内容整体替换、源文件消失、权限保留——守护 atomicWrite 换用 ReplaceFile 后非 Windows 路径行为不变。
+func TestReplaceFileOverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("NEW\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("OLD CONTENT that is long\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReplaceFile(src, dst); err != nil {
+		t.Fatalf("ReplaceFile: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != "NEW\n" {
+		t.Errorf("dst content = %q, want %q", got, "NEW\n")
+	}
+	if _, statErr := os.Stat(src); !os.IsNotExist(statErr) {
+		t.Error("src must not remain after replace")
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("dst perm = %v, want source perm 0600", info.Mode().Perm())
 	}
 }
 

--- a/internal/notifier/cache.go
+++ b/internal/notifier/cache.go
@@ -1,5 +1,5 @@
 /**
- * [INPUT]: 依赖 encoding/json、os、path/filepath、strings、time；依赖 internal/config 的 Dir
+ * [INPUT]: 依赖 encoding/json、os、path/filepath、strings、time；依赖 internal/config 的 Dir 与 ReplaceFile（平台感知的原子替换）
  * [OUTPUT]: 对外提供（包内）cacheData 类型与 readCache/writeCache/cachePath/cleanStaleTemps，及 expired 方法
  * [POS]: internal/notifier 的本地缓存层，持久化最近一次 GitHub 检测结果，供 Start/Finish 消费
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
@@ -88,7 +88,7 @@ func writeCache(c cacheData) error {
 		_ = os.Remove(tmpName)
 		return err
 	}
-	return os.Rename(tmpName, path)
+	return config.ReplaceFile(tmpName, path)
 }
 
 // expired 判定缓存是否已超过 interval（now 显式传入便于测试）


### PR DESCRIPTION
## Summary
- `atomicWrite` 此前直接 `os.Rename` 覆盖目标。Windows 上该原语（`MoveFileEx` + `REPLACE_EXISTING`）在目标被无 `FILE_SHARE_DELETE` 的进程占用（杀毒/索引器/并发 CLI）时会失败，credentials/config/更新缓存的保存随之失败且无退避
- 替换动作收口到 build-tag 分发的 `ReplaceFile`：POSIX 直通 `os.Rename`（`rename(2)` 对既有目标本就原子覆盖，行为零变化）；Windows 只用单步覆盖原语退避重试 3 次 ×10ms
- **失败合同**：任何失败路径都不触碰既有目标——dst 要么已是新内容、要么原样保有旧内容，无路径缺失窗口。刻意不走「先删目标再改名」：二次改名失败即永久丢失最后完好的配置文件
- `internal/notifier` 缓存落盘同步换用 `ReplaceFile`；零额外依赖（不引入 `golang.org/x/sys`）

## Test plan
- `make vet && make test` 全绿；`GOOS=windows go build ./...` 与 `GOOS=windows go vet ./internal/config/` 通过
- Windows 分支合同测试（windows-tagged，`renameFile` 包级变量注入失败）：重复失败后 dst 原样保有旧内容且每次尝试时在位、重试计数正确、前失败后成功的重试出口
- 非 Windows 分支：`TestReplaceFileOverwritesExisting` 守护换用 `ReplaceFile` 后行为不变（内容替换/源消失/权限保留）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
